### PR TITLE
Fix MarkupTest's missing array code convention

### DIFF
--- a/Tests/MarkdownTests/Base/MarkupTests.swift
+++ b/Tests/MarkdownTests/Base/MarkupTests.swift
@@ -272,7 +272,7 @@ final class MarkupTests: XCTestCase {
                 (0, Paragraph.self),
                 (1, Link.self),
                 (0, Emphasis.self),
-                (0, Text.self)
+                (0, Text.self),
             ])!.debugDescription(),
             document.child(through:
                 0, // Paragraph


### PR DESCRIPTION
## Summary

Found the missing code convention of the array in the MarkupTest code. 
So, add it to this.

## Checklist
- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
