### PR TITLE
Fix/remove argument-parser

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,9 +20,6 @@ let package = Package(
         .library(
             name: "Markdown",
             targets: ["Markdown"]),
-        .executable(
-            name: "markdown-tool",
-            targets: ["markdown-tool"]),
     ],
     targets: [
         .target(

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -22,9 +22,6 @@ let package = Package(
         .library(
             name: "Markdown",
             targets: ["Markdown"]),
-        .executable(
-            name: "markdown-tool",
-            targets: ["markdown-tool"]),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary

Remove the executable "markdown-tool" from the product so that ArgumentParser is not added unnecessarily when used it as a library.

In my case, I added swift-markdown to my CLI tool that it uses swift-argument-parser v1.0.1  then I got the following error.

```
Dependencies could not be resolved because root depends on 'swift-argument-parser' 0.4.4..<0.5.0 and root depends on 'swift-argument-parser' 1.0.0..<1.1.0.
```

This PR will fix this issue.

## Dependencies

none.

## Testing

All tests passed my local environment.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
    - I don’t think we need to add tests for this PR. 
- [x] Ran the `./bin/test` script and it succeeded
    -  added Package*.swift as exceptions
- [x] Updated documentation if necessary
    - I don’t think we need to add tests for this PR. 