### PR TITLE
Revert "Fix macOS deprecated API"

### DIFF
--- a/Sources/markdown-tool/Commands/FormatCommand.swift
+++ b/Sources/markdown-tool/Commands/FormatCommand.swift
@@ -126,16 +126,11 @@ extension MarkdownCommand {
         /// Search for the an executable with a given base name.
         func findExecutable(named name: String) throws -> String? {
             let which = Process()
+            which.launchPath = "/usr/bin/which"
             which.arguments = [name]
             let standardOutput = Pipe()
             which.standardOutput = standardOutput
-            if #available(macOS 10.13, *) {
-                which.executableURL = URL(fileURLWithPath: "/usr/bin/which")
-                try which.run()
-            } else {
-                which.launchPath = "/usr/bin/which"
-                which.launch()
-            }
+            which.launch()
             which.waitUntilExit()
 
             guard which.terminationStatus == 0,

--- a/Sources/markdown-tool/main.swift
+++ b/Sources/markdown-tool/main.swift
@@ -30,7 +30,7 @@ struct MarkdownCommand: ParsableCommand {
     ])
 
     static func parseFile(at path: String, options: ParseOptions) throws -> (source: String, parsed: Document) {
-        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let data = try Data(contentsOf: URL( fileURLWithPath: path))
         guard let inputString = String(data: data, encoding: .utf8) else {
             throw Error.couldntDecodeInputAsUTF8
         }
@@ -38,12 +38,7 @@ struct MarkdownCommand: ParsableCommand {
     }
 
     static func parseStandardInput(options: ParseOptions) throws -> (source: String, parsed: Document) {
-        let stdinData: Data
-        if #available(macOS 10.15.4, *) {
-            stdinData = try FileHandle.standardInput.readToEnd() ?? Data()
-        } else {
-            stdinData = FileHandle.standardInput.readDataToEndOfFile()
-        }
+        let stdinData = FileHandle.standardInput.readDataToEndOfFile()
         guard let stdinString = String(data: stdinData, encoding: .utf8) else {
             throw Error.couldntDecodeInputAsUTF8
         }


### PR DESCRIPTION
Unfortunately we need to revert this temporarily to investigate an issue with the Swift toolchain build.

Reverts apple/swift-markdown#3