### PR TITLE
Revert "revert" to test toolchain change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /.build
 /Packages
 /*.xcodeproj
+.swiftpm
+Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,8 @@
 import PackageDescription
 import class Foundation.ProcessInfo
 
+let cmarkPackageName = ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil ? "swift-cmark" : "swift-cmark-gfm"
+
 let package = Package(
     name: "swift-markdown",
     products: [
@@ -27,8 +29,8 @@ let package = Package(
             name: "Markdown",
             dependencies: [
                 "CAtomic",
-                .product(name: "cmark-gfm", package: "swift-cmark"),
-                .product(name: "cmark-gfm-extensions", package: "swift-cmark"),
+                .product(name: "cmark-gfm", package: cmarkPackageName),
+                .product(name: "cmark-gfm-extensions", package: cmarkPackageName),
             ]),
         .target(
             name: "markdown-tool",

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -1,4 +1,6 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
+// In order to support users running on the latest Xcodes, please ensure that
+// Package@swift-5.5.swift is kept in sync with this file.
 /*
  This source file is part of the Swift.org open source project
 
@@ -30,7 +32,7 @@ let package = Package(
                 .product(name: "cmark-gfm", package: "swift-cmark"),
                 .product(name: "cmark-gfm-extensions", package: "swift-cmark"),
             ]),
-        .target(
+        .executableTarget(
             name: "markdown-tool",
             dependencies: [
                 "Markdown",

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -14,6 +14,8 @@
 import PackageDescription
 import class Foundation.ProcessInfo
 
+let cmarkPackageName = ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil ? "swift-cmark" : "swift-cmark-gfm"
+
 let package = Package(
     name: "swift-markdown",
     products: [
@@ -29,8 +31,8 @@ let package = Package(
             name: "Markdown",
             dependencies: [
                 "CAtomic",
-                .product(name: "cmark-gfm", package: "swift-cmark"),
-                .product(name: "cmark-gfm-extensions", package: "swift-cmark"),
+                .product(name: "cmark-gfm", package: cmarkPackageName),
+                .product(name: "cmark-gfm-extensions", package: cmarkPackageName),
             ]),
         .executableTarget(
             name: "markdown-tool",

--- a/Sources/markdown-tool/Commands/FormatCommand.swift
+++ b/Sources/markdown-tool/Commands/FormatCommand.swift
@@ -126,11 +126,16 @@ extension MarkdownCommand {
         /// Search for the an executable with a given base name.
         func findExecutable(named name: String) throws -> String? {
             let which = Process()
-            which.launchPath = "/usr/bin/which"
             which.arguments = [name]
             let standardOutput = Pipe()
             which.standardOutput = standardOutput
-            which.launch()
+            if #available(macOS 10.13, *) {
+                which.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+                try which.run()
+            } else {
+                which.launchPath = "/usr/bin/which"
+                which.launch()
+            }
             which.waitUntilExit()
 
             guard which.terminationStatus == 0,

--- a/Sources/markdown-tool/main.swift
+++ b/Sources/markdown-tool/main.swift
@@ -30,7 +30,7 @@ struct MarkdownCommand: ParsableCommand {
     ])
 
     static func parseFile(at path: String, options: ParseOptions) throws -> (source: String, parsed: Document) {
-        let data = try Data(contentsOf: URL( fileURLWithPath: path))
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
         guard let inputString = String(data: data, encoding: .utf8) else {
             throw Error.couldntDecodeInputAsUTF8
         }
@@ -38,7 +38,12 @@ struct MarkdownCommand: ParsableCommand {
     }
 
     static func parseStandardInput(options: ParseOptions) throws -> (source: String, parsed: Document) {
-        let stdinData = FileHandle.standardInput.readDataToEndOfFile()
+        let stdinData: Data
+        if #available(macOS 10.15.4, *) {
+            stdinData = try FileHandle.standardInput.readToEnd() ?? Data()
+        } else {
+            stdinData = FileHandle.standardInput.readDataToEndOfFile()
+        }
         guard let stdinString = String(data: stdinData, encoding: .utf8) else {
             throw Error.couldntDecodeInputAsUTF8
         }

--- a/Tests/MarkdownTests/Visitors/Everything.md
+++ b/Tests/MarkdownTests/Visitors/Everything.md
@@ -13,15 +13,19 @@
 > BlockQuote
 
 ```swift
-func foo() { let x = 1 }
+func foo() {
+    let x = 1
+}
 ```
+
+    // Is this real code? Or just fantasy?
 
 This is an <topic://autolink>.
 
 ---
 
 <a href="foo.png">
-  An HTML Block.
+An HTML Block.
 </a>
 
 This is some <p>inline html</p>.

--- a/Tests/MarkdownTests/Visitors/MarkupRewriterTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupRewriterTests.swift
@@ -12,45 +12,7 @@ import XCTest
 @testable import Markdown
 
 /// A `Document` that has every kind of element in it at least once.
-let everythingDocument = Document(parsing: """
-        # Header
-
-        *Emphasized* **strong** `inline code` [link](foo) ![image](foo).
-
-        - this
-        - is
-        - a
-        - list
-
-        1. eggs
-        1. milk
-
-        > BlockQuote 
-
-        ```swift
-        func foo() {
-            let x = 1
-        }
-        ```
-
-            // Is this real code? Or just fantasy?
-
-        This is an <topic://autolink>.
-
-        ---
-
-        <a href="foo.png">
-        An HTML Block.
-        </a>
-
-        This is some <p>inline html</p>.
-
-        line  
-        break
-
-        soft
-        break
-        """)
+let everythingDocument = Document(parsing: try! String(contentsOf: Bundle.module.url(forResource: "Everything", withExtension: "md")!))
 
 
 class MarkupRewriterTests: XCTestCase {

--- a/Tests/MarkdownTests/Visitors/MarkupTreeDumperTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupTreeDumperTests.swift
@@ -14,7 +14,7 @@ import XCTest
 final class MarkupTreeDumperTests: XCTestCase {
     func testDumpEverything() {
         let expectedDump = """
-        Document @1:1-37:6 Root #\(everythingDocument.raw.metadata.id.rootId) #0
+        Document @1:1-39:90 Root #\(everythingDocument.raw.metadata.id.rootId) #0
         ├─ Heading @1:1-1:9 #1 level: 1
         │  └─ Text @1:3-1:9 #2 "Header"
         ├─ Paragraph @3:1-3:65 #3
@@ -52,8 +52,8 @@ final class MarkupTreeDumperTests: XCTestCase {
         │  └─ ListItem @11:1-12:1 #35
         │     └─ Paragraph @11:4-11:8 #36
         │        └─ Text @11:4-11:8 #37 "milk"
-        ├─ BlockQuote @13:1-13:14 #38
-        │  └─ Paragraph @13:3-13:14 #39
+        ├─ BlockQuote @13:1-13:13 #38
+        │  └─ Paragraph @13:3-13:13 #39
         │     └─ Text @13:3-13:13 #40 "BlockQuote"
         ├─ CodeBlock @15:1-19:4 #41 language: swift
         │  func foo() {
@@ -81,10 +81,12 @@ final class MarkupTreeDumperTests: XCTestCase {
         │  ├─ Text @33:1-33:7 #57 "line"
         │  ├─ LineBreak #58
         │  └─ Text @34:1-34:6 #59 "break"
-        └─ Paragraph @36:1-37:6 #60
-           ├─ Text @36:1-36:5 #61 "soft"
-           ├─ SoftBreak #62
-           └─ Text @37:1-37:6 #63 "break"
+        ├─ Paragraph @36:1-37:6 #60
+        │  ├─ Text @36:1-36:5 #61 "soft"
+        │  ├─ SoftBreak #62
+        │  └─ Text @37:1-37:6 #63 "break"
+        └─ HTMLBlock @39:1-39:90 #64
+           <!-- Copyright (c) 2021 Apple Inc and the Swift Project authors. All Rights Reserved. -->
         """
         print(everythingDocument.debugDescription(options: [.printEverything]))
         XCTAssertEqual(expectedDump, everythingDocument.debugDescription(options: [.printEverything]))

--- a/bin/check-source
+++ b/bin/check-source
@@ -49,7 +49,7 @@ for language in swift-or-c bash md-or-tutorial html docker; do
   reader=head
   case "$language" in
       swift-or-c)
-        exceptions=( -name Package.swift)
+        exceptions=( -name 'Package*.swift')
         matching_files=( -name '*.swift' -o -name '*.c' -o -name '*.h' )
         cat > "$tmp" <<"EOF"
 /*


### PR DESCRIPTION
- Revert "Revert "Fix deprecated launch and launchPath API on Process""
- Revert "Revert "Fix deprecated readDataToEndOfFile API""
- Revert "Revert "Bump Swift version (#4)" (#11)"

Bug/issue #, if applicable: 

## Summary

Revert #11 and #12 to test the change in the toolchain build.
@franklinsch 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Ran the `./bin/test` script and it succeeded