### PR TITLE
[Optimus] Respect includePath param

### DIFF
--- a/Sources/Markdown/Infrastructure/SourceLocation.swift
+++ b/Sources/Markdown/Infrastructure/SourceLocation.swift
@@ -91,13 +91,12 @@ extension SourceRange {
 
     /// A textual description for use in diagnostics.
     public func diagnosticDescription(includePath: Bool = true) -> String {
-        let path = lowerBound.source.map {
-            $0.path.isEmpty
-                ? ""
-                : "\($0.path):"
-        } ?? ""
-
-        var result =  "\(path)\(lowerBound)"
+        let path = includePath ? lowerBound.source?.path ?? "" : ""
+        var result = ""
+        if !path.isEmpty {
+            result += "\(path):"
+        }
+        result += "\(lowerBound)"
         if lowerBound != upperBound {
             result += "-\(upperBound)"
         }

--- a/Tests/MarkdownTests/Parsing/SourceURLTests.swift
+++ b/Tests/MarkdownTests/Parsing/SourceURLTests.swift
@@ -45,33 +45,33 @@ class SourceURLTests: XCTestCase {
         checker.visit(document)
 
         let expectedDump = """
-        Document @/test.md:/test.md:1:1-/test.md:16:2
-        ├─ Paragraph @/test.md:/test.md:1:1-/test.md:1:21
-        │  └─ Text @/test.md:/test.md:1:1-/test.md:1:21 "This is a paragraph."
-        ├─ UnorderedList @/test.md:/test.md:3:1-/test.md:6:1
-        │  ├─ ListItem @/test.md:/test.md:3:1-/test.md:3:4
-        │  │  └─ Paragraph @/test.md:/test.md:3:3-/test.md:3:4
-        │  │     └─ Text @/test.md:/test.md:3:3-/test.md:3:4 "A"
-        │  └─ ListItem @/test.md:/test.md:4:1-/test.md:6:1
-        │     ├─ Paragraph @/test.md:/test.md:4:3-/test.md:4:4
-        │     │  └─ Text @/test.md:/test.md:4:3-/test.md:4:4 "B"
-        │     └─ UnorderedList @/test.md:/test.md:5:3-/test.md:6:1
-        │        └─ ListItem @/test.md:/test.md:5:3-/test.md:6:1
-        │           └─ Paragraph @/test.md:/test.md:5:5-/test.md:5:6
-        │              └─ Text @/test.md:/test.md:5:5-/test.md:5:6 "C"
-        ├─ BlockQuote @/test.md:/test.md:7:1-/test.md:8:8
-        │  └─ Paragraph @/test.md:/test.md:7:3-/test.md:8:8
-        │     ├─ Text @/test.md:/test.md:7:3-/test.md:7:8 "Quote"
+        Document @/test.md:1:1-/test.md:16:2
+        ├─ Paragraph @/test.md:1:1-/test.md:1:21
+        │  └─ Text @/test.md:1:1-/test.md:1:21 "This is a paragraph."
+        ├─ UnorderedList @/test.md:3:1-/test.md:6:1
+        │  ├─ ListItem @/test.md:3:1-/test.md:3:4
+        │  │  └─ Paragraph @/test.md:3:3-/test.md:3:4
+        │  │     └─ Text @/test.md:3:3-/test.md:3:4 "A"
+        │  └─ ListItem @/test.md:4:1-/test.md:6:1
+        │     ├─ Paragraph @/test.md:4:3-/test.md:4:4
+        │     │  └─ Text @/test.md:4:3-/test.md:4:4 "B"
+        │     └─ UnorderedList @/test.md:5:3-/test.md:6:1
+        │        └─ ListItem @/test.md:5:3-/test.md:6:1
+        │           └─ Paragraph @/test.md:5:5-/test.md:5:6
+        │              └─ Text @/test.md:5:5-/test.md:5:6 "C"
+        ├─ BlockQuote @/test.md:7:1-/test.md:8:8
+        │  └─ Paragraph @/test.md:7:3-/test.md:8:8
+        │     ├─ Text @/test.md:7:3-/test.md:7:8 "Quote"
         │     ├─ SoftBreak
-        │     └─ Text @/test.md:/test.md:8:3-/test.md:8:8 "Quote"
-        ├─ Paragraph @/test.md:/test.md:10:1-/test.md:10:10
-        │  └─ SymbolLink @/test.md:/test.md:10:1-/test.md:10:10 destination: foo()
-        └─ BlockDirective @/test.md:/test.md:12:1-/test.md:16:2 name: "Outer"
-           ├─ BlockDirective @/test.md:/test.md:13:3-/test.md:13:9 name: "Inner"
-           └─ UnorderedList @/test.md:/test.md:15:3-/test.md:15:6
-              └─ ListItem @/test.md:/test.md:15:3-/test.md:15:6
-                 └─ Paragraph @/test.md:/test.md:15:5-/test.md:15:6
-                    └─ Text @/test.md:/test.md:15:5-/test.md:15:6 "A"
+        │     └─ Text @/test.md:8:3-/test.md:8:8 "Quote"
+        ├─ Paragraph @/test.md:10:1-/test.md:10:10
+        │  └─ SymbolLink @/test.md:10:1-/test.md:10:10 destination: foo()
+        └─ BlockDirective @/test.md:12:1-/test.md:16:2 name: "Outer"
+           ├─ BlockDirective @/test.md:13:3-/test.md:13:9 name: "Inner"
+           └─ UnorderedList @/test.md:15:3-/test.md:15:6
+              └─ ListItem @/test.md:15:3-/test.md:15:6
+                 └─ Paragraph @/test.md:15:5-/test.md:15:6
+                    └─ Text @/test.md:15:5-/test.md:15:6 "A"
         """
         XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
     }


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

Respect includePath param

Since  we call  `range.diagnosticDescription(includePath: false)` here, we should respect the false here instead of ignore it.

```swift
    private mutating func dump(_ markup: Markup, customDescription: String? = nil) {
        indent(markup)
        result += "\(type(of: markup))"
        if options.contains(.printSourceLocations),
            let range = markup.range {
            result += " @\(range.diagnosticDescription(includePath: false))"
        }
        if options.contains(.printUniqueIdentifiers) {
            if markup.parent == nil {
                result += " Root #\(markup._data.id.rootId)"
            }
            result += " #\(markup._data.id.childId)"
        }
        if let customDescription = customDescription {
            if !customDescription.starts(with: "\n") {
                result += " "
            }
            result += "\(customDescription)"
        }
        increasingDepth(markup)
    }
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Ran the `./bin/test` script and it succeeded
