### PR TITLE
Add Test for back-tick issue

### DIFF
--- a/Tests/MarkdownTests/Parsing/BacktickTests.swift
+++ b/Tests/MarkdownTests/Parsing/BacktickTests.swift
@@ -1,0 +1,49 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+@testable import Markdown
+import XCTest
+
+class BacktickTests: XCTestCase {
+    func testNormalBackticks() {
+        let string = "Hello `test` String"
+        let document = Document(parsing: string)
+        let expectedDump = """
+        Document @1:1-1:20
+        └─ Paragraph @1:1-1:20
+           ├─ Text @1:1-1:7 "Hello "
+           ├─ InlineCode @1:7-1:13 `test`
+           └─ Text @1:13-1:20 " String"
+        """
+        XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
+    }
+
+    func testOpenBacktick() {
+        let single = "`"
+        let document = Document(parsing: single)
+        let expectedDump = """
+        Document @1:1-1:2
+        └─ Paragraph @1:1-1:2
+           └─ Text @1:1-1:2 "`"
+        """
+        XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
+    }
+
+    func testOpenBackticks(){
+        let double = "``"
+        let document = Document(parsing: double)
+        let expectedDump = """
+        Document @1:1-1:3
+        └─ Paragraph @1:1-1:3
+           └─ Text @1:1-1:3 "``"
+        """
+        XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
+    }
+}


### PR DESCRIPTION
Bug/issue #, if applicable: 
SR-15415

## Summary

- Add test cases for the back-tick parse issue.
~~(Currently use the unmerged version, will reset the dependence once the cmark-PR https://github.com/apple/swift-cmark/pull/26 is merged)~~
- Update swift-argument-parser version in Package@swift-5.5.swift file

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Ran the `./bin/test` script and it succeeded
