### PR TITLE
Fix package manifest

### DIFF
--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -55,7 +55,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-cmark.git", .branch("gfm")),
-        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.4.4")),
+        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
     ]
 } else {
     // Building in the Swift.org CI system, so rely on local versions of dependencies.


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

In current master (c570b5873782f1a1cca5f649ebf1e0bc599bba51), this package uses swift-argument parser `~> 1.0.1`.
https://github.com/apple/swift-markdown/blob/c570b5873782f1a1cca5f649ebf1e0bc599bba51/Package.swift#L56

However, Swift 5.5 still uses 0.4.4.
https://github.com/apple/swift-markdown/blob/c570b5873782f1a1cca5f649ebf1e0bc599bba51/Package%40swift-5.5.swift#L58

Because of this, swift-docc fails to resolve dependencies when it is built as other package's dependencies.

## Dependencies


## Testing

Run tests on Swift 5.5.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
