### PR TITLE
Fix wrong Package desciption text

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,6 @@
 // swift-tools-version:5.3
+// In order to support users running on the latest Xcodes, please ensure that
+// Package@swift-5.5.swift is kept in sync with this file.
 /*
  This source file is part of the Swift.org open source project
 

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -1,5 +1,5 @@
 // swift-tools-version:5.5
-// In order to support users running on legacy Xcodes, please ensure that
+// In order to support users running on previous versions of Xcode, please ensure that
 // Package.swift is kept in sync with this file.
 /*
  This source file is part of the Swift.org open source project

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -1,6 +1,6 @@
 // swift-tools-version:5.5
-// In order to support users running on the latest Xcodes, please ensure that
-// Package@swift-5.5.swift is kept in sync with this file.
+// In order to support users running on legacy Xcodes, please ensure that
+// Package.swift is kept in sync with this file.
 /*
  This source file is part of the Swift.org open source project
 


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

As suggested in #4 by @franklinsch, we should "adding a comment such as apple/swift-driver@main/Package.swift#L2"

It seems there is some accidental mistake on the text in that related PR. This is a fix to that mistake.
