### PR TITLE
Fix project dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@
 import PackageDescription
 import class Foundation.ProcessInfo
 
-let cmarkPackageName = ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil ? "swift-cmark" : "swift-cmark-gfm"
+let cmarkPackageName = ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil ? "cmark-gfm" : "swift-cmark-gfm"
 
 let package = Package(
     name: "swift-markdown",
@@ -51,7 +51,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-cmark.git", .branch("gfm")),
+        .package(name: cmarkPackageName, url: "https://github.com/apple/swift-cmark.git", .branch("gfm")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
     ]
 } else {

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,8 @@ let package = Package(
                 "CAtomic",
                 .product(name: "cmark-gfm", package: cmarkPackageName),
                 .product(name: "cmark-gfm-extensions", package: cmarkPackageName),
-            ]),
+            ],
+            exclude: ["Markdown.docc"]),
         .target(
             name: "markdown-tool",
             dependencies: [

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -14,7 +14,7 @@
 import PackageDescription
 import class Foundation.ProcessInfo
 
-let cmarkPackageName = ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil ? "swift-cmark" : "swift-cmark-gfm"
+let cmarkPackageName = ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil ? "cmark-gfm" : "swift-cmark-gfm"
 
 let package = Package(
     name: "swift-markdown",
@@ -51,7 +51,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-cmark.git", .branch("gfm")),
+        .package(name: cmarkPackageName, url: "https://github.com/apple/swift-cmark.git", .branch("gfm")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
     ]
 } else {

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -30,7 +30,8 @@ let package = Package(
                 "CAtomic",
                 .product(name: "cmark-gfm", package: cmarkPackageName),
                 .product(name: "cmark-gfm-extensions", package: cmarkPackageName),
-            ]),
+            ],
+            exclude: ["Markdown.docc"]),
         .executableTarget(
             name: "markdown-tool",
             dependencies: [

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -30,8 +30,7 @@ let package = Package(
                 "CAtomic",
                 .product(name: "cmark-gfm", package: cmarkPackageName),
                 .product(name: "cmark-gfm-extensions", package: cmarkPackageName),
-            ],
-            exclude: ["Markdown.docc"]),
+            ]),
         .executableTarget(
             name: "markdown-tool",
             dependencies: [


### PR DESCRIPTION
Bug/issue #, if applicable: n/a

## Summary

The current `main` branch cannot be used as a Swift Package Manager dependency as package resolution results in:

```
product dependency 'cmark-gfm' in package 'swift-cmark' not found
product dependency 'cmark-gfm-extensions' in package 'swift-cmark' not found
```

The dependency also generates the following warning:

```
found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    «path»/SourcePackages/checkouts/swift-markdown/Sources/Markdown/Markdown.docc
```

I excluded this file to avoid the warning.

## Dependencies

None

## Testing

With a new Xcode project attempt to include the `main` branch as documented by using:

`.package(url: "ssh://git@github.com/apple/swift-markdown.git", .branch("main")),`

or 

`.package(url: "https://github.com/apple/swift-markdown", .branch("main")),`

Package resolution will fail with the errors above.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary

None necessary
