### PR TITLE
Add support for custom attributes

### DIFF
--- a/Sources/Markdown/Base/Markup.swift
+++ b/Sources/Markdown/Base/Markup.swift
@@ -69,6 +69,8 @@ func makeMarkup(_ data: _MarkupData) -> Markup {
         return Table.Cell(data)
     case .symbolLink:
         return SymbolLink(data)
+    case .inlineAttributes:
+        return InlineAttributes(data)
     }
 }
 

--- a/Sources/Markdown/Base/RawMarkup.swift
+++ b/Sources/Markdown/Base/RawMarkup.swift
@@ -40,6 +40,7 @@ enum RawMarkupData: Equatable {
     case strong
     case text(String)
     case symbolLink(destination: String?)
+    case inlineAttributes(attributes: String)
 
     // Extensions
     case strikethrough
@@ -288,6 +289,10 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
 
     static func symbolLink(parsedRange: SourceRange?, destination: String?) -> RawMarkup {
         return .create(data: .symbolLink(destination: destination), parsedRange: parsedRange, children:  [])
+    }
+
+    static func inlineAttributes(attributes: String, parsedRange: SourceRange?, _ children: [RawMarkup]) -> RawMarkup {
+        return .create(data: .inlineAttributes(attributes: attributes), parsedRange: parsedRange, children: children)
     }
 
     // MARK: Extensions

--- a/Sources/Markdown/Inline Nodes/Inline Containers/InlineAttributes.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/InlineAttributes.swift
@@ -1,0 +1,59 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// A set of one or more inline attributes.
+public struct InlineAttributes: InlineMarkup, InlineContainer {
+    public var _data: _MarkupData
+
+    init(_ raw: RawMarkup) throws {
+        guard case .inlineAttributes = raw.data else {
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: InlineAttributes.self)
+        }
+        let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
+        self.init(_MarkupData(absoluteRaw))
+    }
+
+    init(_ data: _MarkupData) {
+        self._data = data
+    }
+}
+
+// MARK: - Public API
+
+public extension InlineAttributes {
+    /// Create a set of custom inline attributes applied to zero or more child inline elements.
+    init<Children: Sequence>(attributes: String, _ children: Children) where Children.Element == RecurringInlineMarkup {
+        try! self.init(.inlineAttributes(attributes: attributes, parsedRange: nil, children.map { $0.raw.markup }))
+    }
+
+    /// Create a set of custom attributes applied to zero or more child inline elements.
+    init(attributes: String, _ children: RecurringInlineMarkup...) {
+        self.init(attributes: attributes, children)
+    }
+    
+    /// The specified attributes in JSON5 format.
+    var attributes: String {
+        get {
+            guard case let .inlineAttributes(attributes) = _data.raw.markup.data else {
+                fatalError("\(self) markup wrapped unexpected \(_data.raw)")
+            }
+            return attributes
+        }
+        set {
+            _data = _data.replacingSelf(.inlineAttributes(attributes: newValue, parsedRange: nil, _data.raw.markup.copyChildren()))
+        }
+    }
+    
+    // MARK: Visitation
+
+    func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
+        return visitor.visitInlineAttributes(self)
+    }
+}

--- a/Sources/Markdown/Rewriter/MarkupRewriter.swift
+++ b/Sources/Markdown/Rewriter/MarkupRewriter.swift
@@ -75,6 +75,9 @@ extension MarkupRewriter {
     public mutating func visitLink(_ link: Link) -> Result {
         return defaultVisit(link)
     }
+    public mutating func visitInlineAttributes(_ attributes: InlineAttributes) -> Result {
+        return defaultVisit(attributes)
+    }
     public mutating func visitSoftBreak(_ softBreak: SoftBreak) -> Result {
         return defaultVisit(softBreak)
     }

--- a/Sources/Markdown/Visitor/MarkupVisitor.swift
+++ b/Sources/Markdown/Visitor/MarkupVisitor.swift
@@ -266,6 +266,14 @@ public protocol MarkupVisitor {
      - returns: The result of the visit.
      */
     mutating func visitSymbolLink(_ symbolLink: SymbolLink) -> Result
+
+    /**
+    Visit an `InlineAttributes` element and return the result.
+
+    - parameter attribute: An `InlineAttributes` element.
+    - returns: The result of the visit.
+     */
+     mutating func visitInlineAttributes(_ attributes: InlineAttributes) -> Result
 }
 
 extension MarkupVisitor {
@@ -361,5 +369,8 @@ extension MarkupVisitor {
     }
     public mutating func visitSymbolLink(_ symbolLink: SymbolLink) -> Result {
         return defaultVisit(symbolLink)
+    }
+    public mutating func visitInlineAttributes(_ attributes: InlineAttributes) -> Result {
+        return defaultVisit(attributes)
     }
 }

--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -1120,4 +1120,28 @@ public struct MarkupFormatter: MarkupWalker {
         print(symbolLink.destination ?? "", for: symbolLink)
         print("``", for: symbolLink)
     }
+
+    public mutating func visitInlineAttributes(_ attributes: InlineAttributes) {
+        let savedState = state
+        func printInlineAttributes() {
+            print("[", for: attributes)
+            descendInto(attributes)
+            print("](", for: attributes)
+            print(attributes.attributes, for: attributes)
+            print(")", for: attributes)
+        }
+    
+        printInlineAttributes()
+
+        // Inline attributes *can* have their key-value pairs split across multiple
+        // lines as they are formatted as JSON5, however formatting the output as such
+        // gets into the realm of JSON formatting which might be out of scope of
+        // this formatter. Therefore if exceeded, prefer to print it on the next
+        // line to give as much opportunity to keep the attributes on one line.
+        if attributes.indexInParent > 0 && (isOverPreferredLineLimit || state.lineNumber > savedState.lineNumber) {
+            restoreState(to: savedState)
+            queueNewline()
+            printInlineAttributes()
+        }
+    }
 }

--- a/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
@@ -282,4 +282,8 @@ struct MarkupTreeDumper: MarkupWalker {
             dump(tableCell)
         }
     }
+
+    mutating func visitInlineAttributes(_ attributes: InlineAttributes) -> () {
+        dump(attributes, customDescription: "attributes: `\(attributes.attributes)`")
+    }
 }

--- a/Tests/MarkdownTests/Inline Nodes/InlineAttributesTests.swift
+++ b/Tests/MarkdownTests/Inline Nodes/InlineAttributesTests.swift
@@ -34,4 +34,16 @@ class InlineAttributesTests: XCTestCase {
             """
         XCTAssertEqual(expectedDump, inlineAttributes.debugDescription())
     }
+    
+    func testParseInlineAttributes() {
+        let source = "^[Hello, world!](rainbow: 'extreme')"
+        let document = Document(parsing: source)
+        let expectedDump = """
+            Document @1:1-1:37
+            └─ Paragraph @1:1-1:37
+               └─ InlineAttributes @1:1-1:37 attributes: `rainbow: 'extreme'`
+                  └─ Text @1:3-1:16 "Hello, world!"
+            """
+        XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
+    }
 }

--- a/Tests/MarkdownTests/Inline Nodes/InlineAttributesTests.swift
+++ b/Tests/MarkdownTests/Inline Nodes/InlineAttributesTests.swift
@@ -1,0 +1,37 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+@testable import Markdown
+
+class InlineAttributesTests: XCTestCase {
+    func testInlineAttributesAttributes() {
+        let attributes = "rainbow: 'extreme'"
+        let inlineAttributes = InlineAttributes(attributes: attributes)
+        XCTAssertEqual(attributes, inlineAttributes.attributes)
+        XCTAssertEqual(0, inlineAttributes.childCount)
+
+        let newAttributes = "rainbow: 'medium'"
+        var newInlineAttributes = inlineAttributes
+        newInlineAttributes.attributes = newAttributes
+        XCTAssertEqual(newAttributes, newInlineAttributes.attributes)
+        XCTAssertFalse(inlineAttributes.isIdentical(to: newInlineAttributes))
+    }
+    
+    func testInlineAttributesFromSequence() {
+        let children = [Text("Hello, world!")]
+        let inlineAttributes = InlineAttributes(attributes: "rainbow: 'extreme'", children)
+        let expectedDump = """
+            InlineAttributes attributes: `rainbow: 'extreme'`
+            └─ Text "Hello, world!"
+            """
+        XCTAssertEqual(expectedDump, inlineAttributes.debugDescription())
+    }
+}


### PR DESCRIPTION
Currently the library will crash if you input Markdown such as the following:

```markdown
Here is a ^[custom attribute](rainbow: 'extreme')
```

This is because while the swift-cmark side of things is [knowledgeable about custom attributes](https://github.com/apple/swift-cmark/blob/gfm/api_test/main.c#L1259) (also see WWDC21 "[What's New in Foundation](https://developer.apple.com/videos/play/wwdc2021/10109/?time=612) @ 10:12" for its usage), this library's Swift counterpart to the C code isn't aware of custom attributes, and [fatal errors with an unknown type](https://github.com/apple/swift-markdown/blob/16ebb0ccea68c0009f550bd48cca1df8675685dc/Sources/Markdown/Parser/CommonMarkConverter.swift#L138-L140) if such an example is encountered. (Ask me how I know!)

This PR adds a `CustomAttributes` Swift type into the library as well as some functions to get it to work, thereby preventing the crash and letting users implement custom attributes in their Walkers/Visitors/Rewriters. 

Some design decisions I wasn't 100% sure of:

- The name `CustomAttributes`. The plural does seem necessary as the actual custom attributes (per the WWDC video) can be JSON5 with any number of attributes, rather than just 1 in the example above. `Custom` as a prefix is also debatable, but `Attributes` felt too generic, and `CustomBlock` already exists.
- For the user-facing Walker API, I wasn't sure if the `CustomAttributes` object should have a value that is a `String` (the raw string/JSON representing the attributes), or a `[String: AnyHashable]` dictionary where the values are actually broken down. I erred on the side of a string, as it would allow the user to ingest it more flexibly, through a custom `Codable` implementation, `JSONSerialization`, etc. rather trivially, instead of the API trying to guess what they want their output as.
- In the same vein, the output for `MarkupFormatter` could technically have each key-value pair on a separate line to better adhere to `preferredLineLimit`, however formatting the output as such also gets into the weeds of JSON formatting, proper indentation, and things likely beyond the scope of the formatter so I elected not to. 

*(Thank you to @QuietMisdreavus for help.)*