### PR TITLE
Fix typo in documentation for `MarkupVisitor`

### DIFF
--- a/Sources/Markdown/Visitor/MarkupVisitor.swift
+++ b/Sources/Markdown/Visitor/MarkupVisitor.swift
@@ -12,7 +12,7 @@
 ///
 /// - note: This interface only provides requirements for visiting each kind of element. It does not require each visit method to descend into child elements.
 ///
-/// Generally, ``MarkupWalker`` is best for walking a ``Markup`` tree if the ``Result`` type is `Void` or is built up some other way, or ``MarkupRewriter`` for recursively changing a tree's structure. This type serves as a common interface to both. However, for building up other structured result types you can implement ``MarkupWalker`` directly.
+/// Generally, ``MarkupWalker`` is best for walking a ``Markup`` tree if the ``Result`` type is `Void` or is built up some other way, or ``MarkupRewriter`` for recursively changing a tree's structure. This type serves as a common interface to both. However, for building up other structured result types you can implement ``MarkupVisitor`` directly.
 public protocol MarkupVisitor {
 
     /**


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

Fixes typo: ``MarkupWalker`` was specified where ``MarkupVisitor`` was intended.


## Dependencies


## Testing


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests: not applicable to documentation
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
