### PR TITLE
Add support for an initial directive argument without a name

### DIFF
--- a/Sources/Markdown/Base/DirectiveArgument.swift
+++ b/Sources/Markdown/Base/DirectiveArgument.swift
@@ -178,8 +178,11 @@ public struct DirectiveArgumentText: Equatable {
         /// Parse the line segment as name-value argument pairs separated by commas.
         ///
         /// ```
-        /// name-value-arguments -> name-value-argument name-value-arguments-rest
+        /// arguments -> first-argument name-value-arguments-rest
+        /// first-argument -> value-only-argument | name-value-argument
+        /// value-only-argument -> literal
         /// name-value-argument -> literal : literal
+        /// name-value-arguments -> name-value-argument name-value-arguments-rest
         /// name-value-arguments-rest -> , name-value-arguments | ε
         /// ```
         ///
@@ -188,6 +191,8 @@ public struct DirectiveArgumentText: Equatable {
         /// - An argument-name pair is only recognized within a single line or line segment;
         ///   that is, an argument cannot span multiple lines.
         /// - A comma is expected between name-value pairs.
+        /// - The first argument can be unnamed. An unnamed argument will have an empty ``DirectiveArgument/name`` with no ``DirectiveArgument/nameRange``.
+        ///
         /// - Parameter diagnosticEngine: the diagnostic engine to use for emitting diagnostics.
         /// - Returns: an array of successfully parsed ``DirectiveArgument`` values.
         public func parseNameValueArguments(parseErrors: inout [ParseError]) -> [DirectiveArgument] {
@@ -298,8 +303,11 @@ public struct DirectiveArgumentText: Equatable {
     /// Parse the line segments as name-value argument pairs separated by commas.
     ///
     /// ```
-    /// name-value-arguments -> name-value-argument name-value-arguments-rest
+    /// arguments -> first-argument name-value-arguments-rest
+    /// first-argument -> value-only-argument | name-value-argument
+    /// value-only-argument -> literal
     /// name-value-argument -> literal : literal
+    /// name-value-arguments -> name-value-argument name-value-arguments-rest
     /// name-value-arguments-rest -> , name-value-arguments | ε
     /// ```
     ///
@@ -308,6 +316,8 @@ public struct DirectiveArgumentText: Equatable {
     /// - An argument-name pair is only recognized within a single line or line segment;
     ///   that is, an argument cannot span multiple lines.
     /// - A comma is expected between name-value pairs.
+    /// - The first argument can be unnamed. An unnamed argument will have an empty ``DirectiveArgument/name`` with no ``DirectiveArgument/nameRange``.
+    ///
     /// - Parameter parseErrors: an array to collect errors while parsing arguments.
     /// - Returns: an array of successfully parsed ``DirectiveArgument`` values.
     public func parseNameValueArguments(parseErrors: inout [ParseError]) -> [DirectiveArgument] {
@@ -340,8 +350,11 @@ public struct DirectiveArgumentText: Equatable {
     /// Parse the line segments as name-value argument pairs separated by commas.
     ///
     /// ```
-    /// name-value-arguments -> name-value-argument name-value-arguments-rest
+    /// arguments -> first-argument name-value-arguments-rest
+    /// first-argument -> value-only-argument | name-value-argument
+    /// value-only-argument -> literal
     /// name-value-argument -> literal : literal
+    /// name-value-arguments -> name-value-argument name-value-arguments-rest
     /// name-value-arguments-rest -> , name-value-arguments | ε
     /// ```
     ///
@@ -350,6 +363,8 @@ public struct DirectiveArgumentText: Equatable {
     /// - An argument-name pair is only recognized within a single line or line segment;
     ///   that is, an argument cannot span multiple lines.
     /// - A comma is expected between name-value pairs.
+    /// - The first argument can be unnamed. An unnamed argument will have an empty ``DirectiveArgument/name`` with no ``DirectiveArgument/nameRange``.
+    ///
     /// - Returns: an array of successfully parsed ``DirectiveArgument`` values.
     ///
     /// This overload discards parse errors.

--- a/Sources/Markdown/Markdown.docc/Markdown.md
+++ b/Sources/Markdown/Markdown.docc/Markdown.md
@@ -36,3 +36,5 @@ The markup tree provided by this package is comprised of immutable/persistent, t
 
 - <doc:VisitMarkup> 
 - <doc:FormatterAndOptions>
+
+<!-- Copyright (c) 2021-2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/Markdown/Markdown.docc/Markdown/BlockDirectives.md
+++ b/Sources/Markdown/Markdown.docc/Markdown/BlockDirectives.md
@@ -73,12 +73,18 @@ You can parse argument text segments however you like. Swift Markdown also inclu
 
 When using the name-value argument parser, this results in arguments `x` with value `1` and `y` with value `2`. Names and values are both strings; it's up to you to decide how to convert them into something more specific.
 
+When using the name-value argument parser, the first argument can be unnamed for when the directive name also describes the purpose of the first argument. This parsed name-value pair will have an empty name. All other arguments have both names and values. 
+
 Here is the grammar of name-value argument syntax:
 
 ```
-Arguments -> Argument ArgumentsRest?
-ArgumentsRest -> , Arguments
+Arguments -> FirstArgument ArgumentsRest?
+ArgumentsRest -> , NamedArguments
+NamedArguments -> Argument ArgumentsRest?
+FirstArgument -> UnnamedArgument
+               | Argument
 Argument -> Literal : Literal
+UnnamedArgument -> Literal
 Literal -> QuotedLiteral
          | UnquotedLiteral
 QuotedLiteral -> " QuotedLiteralContent "
@@ -171,4 +177,4 @@ for diagnostic in collector.diagnostics {
 }
 ```
 
-<!-- Copyright (c) 2021 Apple Inc and the Swift Project authors. All Rights Reserved. -->
+<!-- Copyright (c) 2021-2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/bin/check-source
+++ b/bin/check-source
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][78901]-20[12][8901]/YEARS/' -e 's/20[12][8901]/YEARS/'
+    sed -e 's/20[12][78901]-20[12][89012]/YEARS/' -e 's/20[12][89012]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language… "


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This adds support for the first directive argument to be unlabeled / unnamed. This can be useful—avoid duplication in the authoring syntax—when the directive name acts also describes the first argument. For example:
```
@DisplayName("A custom name")
```
instead of 
```
@DisplayName(name: "A custom name")
```

Only the first argument is can be unlabeled / unnamed. I feel that this provides most of the authoring syntax benefits without impacting the ability to diagnose directive argument syntax errors.

## Dependencies

n/a

## Testing

I will update this with testing instructions when I mark this as non-draft.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
