### PR TITLE
Prefer HTTPS protocol in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The markup tree provided by this package is comprised of immutable/persistent, t
 In your `Package.swift` Swift Package Manager manifest, add the following dependency to your `dependencies` argument:
 
 ```swift
-.package(url: "ssh://git@github.com/apple/swift-markdown.git", .branch("main")),
+.package(url: "https://github.com/apple/swift-markdown.git", .branch("main")),
 ```
 
 Add the dependency to any targets you've declared in your manifest:


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

in current README, SSH protocol is used as protocol for SwiftPM.

but it requires SSH keys, this might not suitable for CI environments and peoples that don't have github.com account or prefer HTTPS authentication.

so change it to HTTPS protocol.

## Dependencies

## Testing

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests: not applicable to change README
- [ ] Ran the `./bin/test` script and it succeeded: not applicable to change README
- [ ] Updated documentation if necessary: not applicable to change README
