### PR TITLE
Publish Swift Markdown's documentation to GitHub pages

### DIFF
--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -54,6 +54,13 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-cmark.git", .branch("gfm")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
     ]
+    
+    // SwiftPM command plugins are only supported by Swift version 5.6 and later.
+    #if swift(>=5.6)
+    package.dependencies += [
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+    ]
+    #endif
 } else {
     // Building in the Swift.org CI system, so rely on local versions of dependencies.
     package.dependencies += [

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ Add the dependency to any targets you've declared in your manifest:
 .target(name: "MyTarget", dependencies: ["Markdown"]),
 ```
 
-## Parsing
-
 To parse a document, use `Document(parsing:)`, supplying a `String` or `URL`:
 
 ```swift
@@ -38,132 +36,8 @@ print(document.debugDescription())
 //    └─ Text "."
 ```
 
-Parsing text is just one way to build a tree of `Markup` elements. You can also build them yourself declaratively.
-
-## Building Markup Trees
-
-You can build trees using initializers for the various element types provided.
-
-```swift
-import Markdown
-
-let document = Document(
-    Paragraph(
-        Text("This is a "),
-        Emphasis(
-            Text("paragraph."))))
-```
-
-This would be equivalent to parsing `"This is a *paragraph.*"` but allows you to programmatically insert content from other data sources into individual elements.
-
-## Modifying Markup Trees with Persistence
-
-Swift Markdown uses a [persistent](https://en.wikipedia.org/wiki/Persistent_data_structure) tree for its backing storage, providing effectively immutable, copy-on-write value types that only copy the substructure necessary to create a unique root without affecting the previous version of the tree.
-
-### Modifying Elements Directly
-
-If you just need to make a quick change, you can modify an element anywhere in a tree, and Swift Markdown will create copies of substructure that cannot be shared.
-
-```swift
-import Markdown
-
-let source = "This is *emphasized.*"
-let document = Document(parsing: source)
-print(document.debugDescription())
-// Document
-// └─ Paragraph
-//    ├─ Text "This is "
-//    └─ Emphasis
-//       └─ Text "emphasized."
-
-var text = document.child(through:
-    0, // Paragraph
-    1, // Emphasis
-    0) as! Text // Text
-
-text.string = "really emphasized!"
-print(text.root.debugDescription())
-// Document
-// └─ Paragraph
-//    ├─ Text "This is "
-//    └─ Emphasis
-//       └─ Text "really emphasized!"
-
-// The original document is unchanged:
-
-print(document.debugDescription())
-// Document
-// └─ Paragraph
-//    ├─ Text "This is "
-//    └─ Emphasis
-//       └─ Text "emphasized."
-```
-
-If you find yourself needing to systematically change many parts of a tree, or even provide a complete transformation into something else, maybe the familiar [Visitor Pattern](https://en.wikipedia.org/wiki/Visitor_pattern) is what you want.
-
-## Visitors, Walkers, and Rewriters
-
-There is a core `MarkupVisitor` protocol that provides the basis for transforming, walking, or rewriting a markup tree.
-
-```swift
-public protocol MarkupVisitor {
-    associatedtype Result
-}
-```
-
-Using its `Result` type, you can transform a markup tree into anything: another markup tree, or perhaps a tree of XML or HTML elements. There are two included refinements of `MarkupVisitor` for common uses.
-
-The first refinement, `MarkupWalker`, has an associated `Result` type of `Void`, so it's meant for summarizing or detecting aspects of a markup tree. If you wanted to append to a string as elements are visited, this might be a good tool for that.
-
-```swift
-import Markdown
-
-/// Counts `Link`s in a `Document`.
-struct LinkCounter: MarkupWalker {
-    var count = 0
-    mutating func visitLink(_ link: Link) {
-        if link.destination == "https://swift.org" {
-            count += 1
-        }
-        descendInto(link)
-    }
-}
-
-let source = "There are [two](https://swift.org) links to <https://swift.org> here."
-let document = Document(parsing: source)
-print(document.debugDescription())
-var linkCounter = LinkCounter()
-linkCounter.visit(document)
-print(linkCounter.count)
-// 2
-```
-
-The second refinement, `MarkupRewriter`, has an associated `Result` type of `Markup?`, so it's meant to change or even remove elements from a markup tree. You can return `nil` to delete an element, or return another element to substitute in its place.
-
-```swift
-import Markdown
-
-/// Delete all **strong** elements in a markup tree.
-struct StrongDeleter: MarkupRewriter {
-    mutating func visitStrong(_ strong: Strong) -> Markup? {
-        return nil
-    }
-}
-
-let source = "Now you see me, **now you don't**"
-let document = Document(parsing: source)
-var strongDeleter = StrongDeleter()
-let newDocument = strongDeleter.visit(document)
-
-print(newDocument!.debugDescription())
-// Document
-// └─ Paragraph
-//    └─ Text "Now you see me, "
-```
-
-## Block Directives
-
-Swift Markdown includes a syntax extension for attributed block elements. See [Block Directive](Documentation/BlockDirectives.md) documentation for more information.
+Please see Swift `Markdown`'s [documentation site](https://apple.github.io/swift-markdown/documentation/markdown/)
+for more detailed information about the library.
 
 ## Getting Involved
 

--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ Swift Markdown can be improved to better meet your needs.
 
 Please see the [contributing guide](https://swift.org/contributing/#contributing-code) for more information.
 
-<!-- Copyright (c) 2021 Apple Inc and the Swift Project authors. All Rights Reserved. -->
+<!-- Copyright (c) 2021-2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/Markdown/Base/DirectiveArgument.swift
+++ b/Sources/Markdown/Base/DirectiveArgument.swift
@@ -156,7 +156,7 @@ public struct DirectiveArgumentText: Equatable {
         ///   - required: whether the character is required
         ///   - allowEscape: whether to allow the character to be escaped
         ///   - diagnoseIfNotFound: if `true` and the character was both required and not found, emit a diagnostic
-        ///   - diagnosticEngine: the diagnostic engine to use if diagnosing
+        ///   - parseErrors: an array to update with any errors encountered while parsing
         /// - Returns: `true` if the character was found.
         func parseCharacter(_ character: Character,
                             from line: inout TrimmedLine,
@@ -193,7 +193,7 @@ public struct DirectiveArgumentText: Equatable {
         /// - A comma is expected between name-value pairs.
         /// - The first argument can be unnamed. An unnamed argument will have an empty ``DirectiveArgument/name`` with no ``DirectiveArgument/nameRange``.
         ///
-        /// - Parameter diagnosticEngine: the diagnostic engine to use for emitting diagnostics.
+        /// - Parameter parseErrors: an array to update with any errors encountered while parsing
         /// - Returns: an array of successfully parsed ``DirectiveArgument`` values.
         public func parseNameValueArguments(parseErrors: inout [ParseError]) -> [DirectiveArgument] {
             var arguments = [DirectiveArgument]()

--- a/Sources/Markdown/Markdown.docc/Markdown.md
+++ b/Sources/Markdown/Markdown.docc/Markdown.md
@@ -8,7 +8,12 @@ The parser is powered by GitHub-flavored Markdown's [cmark-gfm](https://github.c
 
 The markup tree provided by this package is comprised of immutable/persistent, thread-safe, copy-on-write value types that only copy substructure that has changed. Other examples of the main strategy behind this library can be seen in Swift's [lib/Syntax](https://github.com/apple/swift/tree/master/lib/Syntax) and its Swift bindings, [SwiftSyntax](https://github.com/apple/swift-syntax).
 
-## Topics 
+## Topics
+
+### Getting Started
+
+- <doc:Parsing-Building-and-Modifying-Markup-Trees>
+- <doc:Visitors-Walkers-and-Rewriters>
 
 ### Essentials
 

--- a/Sources/Markdown/Markdown.docc/Markdown/BlockDirectives.md
+++ b/Sources/Markdown/Markdown.docc/Markdown/BlockDirectives.md
@@ -150,4 +150,9 @@ Pass the `.parseBlockDirectives` option when parsing a document to enable block 
 let document = Document(parsing: source, options: .parseBlockDirectives)
 ```
 
+## Collecting Diagnostics
+
+When parsing block directive syntax, you can optionally provide an array of errors 
+to collect parsing problems and report them to a user. See ``DirectiveArgumentText/ParseError``.
+
 <!-- Copyright (c) 2021-2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/Markdown/Markdown.docc/Markdown/BlockDirectives.md
+++ b/Sources/Markdown/Markdown.docc/Markdown/BlockDirectives.md
@@ -150,31 +150,4 @@ Pass the `.parseBlockDirectives` option when parsing a document to enable block 
 let document = Document(parsing: source, options: .parseBlockDirectives)
 ```
 
-## Collecting Diagnostics
-
-When parsing block directive syntax, Swift Markdown supplies an optional diagnostic infrastructure for reporting parsing problems to a user. See ``Diagnostic``, ``DiagnosticEngine``, and ``DiagnosticConsumer``.
-
-Here is a simple case if you just want to collect diagnostics:
-
-```swift
-class DiagnosticCollector: DiagnosticConsumer {
-    var diagnostics = [Diagnostic]()
-    func receive(_ diagnostic: Diagnostic) {
-        diagnostics.append(diagnostic)
-    }
-}
-
-let collector = DiagnosticCollector()
-let diagnostics = DiagnosticEngine()
-diagnostics.subscribe(collector)
-
-let document = Document(parsing: source,
-                        options: .parseBlockDirectives,
-                        diagnostics: diagnostics)
-
-for diagnostic in collector.diagnostics {
-  print(diagnostic)
-}
-```
-
 <!-- Copyright (c) 2021-2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/Markdown/Markdown.docc/Markdown/BlockMarkup.md
+++ b/Sources/Markdown/Markdown.docc/Markdown/BlockMarkup.md
@@ -26,3 +26,5 @@
 
 ## See Also
 - <doc:BlockDirectives> 
+
+<!-- Copyright (c) 2021-2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/Markdown/Markdown.docc/Markdown/FormatterAndOptions.md
+++ b/Sources/Markdown/Markdown.docc/Markdown/FormatterAndOptions.md
@@ -9,3 +9,5 @@
 ### Options
 
 - ``MarkupDumpOptions``
+
+<!-- Copyright (c) 2021-2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/Markdown/Markdown.docc/Markdown/Infrastructure.md
+++ b/Sources/Markdown/Markdown.docc/Markdown/Infrastructure.md
@@ -10,3 +10,5 @@
 
 - ``SourceLocation``
 - ``SourceRange``
+
+<!-- Copyright (c) 2021-2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/Markdown/Markdown.docc/Markdown/InlineMarkup.md
+++ b/Sources/Markdown/Markdown.docc/Markdown/InlineMarkup.md
@@ -17,3 +17,5 @@
 - ``SoftBreak``
 - ``SymbolLink``
 - ``Text``
+
+<!-- Copyright (c) 2021-2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/Markdown/Markdown.docc/Markdown/VisitMarkup.md
+++ b/Sources/Markdown/Markdown.docc/Markdown/VisitMarkup.md
@@ -15,3 +15,5 @@
 ### Rewriter
 
 - ``MarkupRewriter``
+
+<!-- Copyright (c) 2021-2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/Markdown/Markdown.docc/Parsing-Building-and-Modifying Markup-Trees.md
+++ b/Sources/Markdown/Markdown.docc/Parsing-Building-and-Modifying Markup-Trees.md
@@ -1,0 +1,86 @@
+# Parsing, Building, and Modifying Markup Trees
+
+Get started with Swift-Markdown's markup trees.
+
+## Parsing
+
+To create a new ``Document`` by parsing markdown content, use Document's ``Document/init(parsing:options:)`` initializer, supplying a `String` or `URL`:
+
+```swift
+import Markdown
+
+let source = "This is a markup *document*."
+let document = Document(parsing: source)
+print(document.debugDescription())
+// Document
+// └─ Paragraph
+//    ├─ Text "This is a markup "
+//    ├─ Emphasis
+//    │  └─ Text "document"
+//    └─ Text "."
+```
+
+Parsing text is just one way to build a tree of ``Markup`` elements. You can also build them yourself declaratively.
+
+## Building Markup Trees
+
+You can build trees using initializers for the various element types provided.
+
+```swift
+import Markdown
+
+let document = Document(
+    Paragraph(
+        Text("This is a "),
+        Emphasis(
+            Text("paragraph."))))
+```
+
+This would be equivalent to parsing `"This is a *paragraph.*"` but allows you to programmatically insert content from other data sources into individual elements.
+
+## Modifying Markup Trees with Persistence
+
+Swift Markdown uses a [persistent](https://en.wikipedia.org/wiki/Persistent_data_structure) tree for its backing storage, providing effectively immutable, copy-on-write value types that only copy the substructure necessary to create a unique root without affecting the previous version of the tree.
+
+### Modifying Elements Directly
+
+If you just need to make a quick change, you can modify an element anywhere in a tree, and Swift Markdown will create copies of substructure that cannot be shared.
+
+```swift
+import Markdown
+
+let source = "This is *emphasized.*"
+let document = Document(parsing: source)
+print(document.debugDescription())
+// Document
+// └─ Paragraph
+//    ├─ Text "This is "
+//    └─ Emphasis
+//       └─ Text "emphasized."
+
+var text = document.child(through:
+    0, // Paragraph
+    1, // Emphasis
+    0) as! Text // Text
+
+text.string = "really emphasized!"
+print(text.root.debugDescription())
+// Document
+// └─ Paragraph
+//    ├─ Text "This is "
+//    └─ Emphasis
+//       └─ Text "really emphasized!"
+
+// The original document is unchanged:
+
+print(document.debugDescription())
+// Document
+// └─ Paragraph
+//    ├─ Text "This is "
+//    └─ Emphasis
+//       └─ Text "emphasized."
+```
+
+If you find yourself needing to systematically change many parts of a tree, or even provide a complete transformation into something else, maybe the familiar [Visitor Pattern](https://en.wikipedia.org/wiki/Visitor_pattern) is what you want.
+
+<!-- Copyright (c) 2021-2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/Markdown/Markdown.docc/Visitors-Walkers-and-Rewriters.md
+++ b/Sources/Markdown/Markdown.docc/Visitors-Walkers-and-Rewriters.md
@@ -1,0 +1,69 @@
+# Visitors, Walkers, and Rewriters
+
+Use `MarkupVisitor` to transform, walk, and rewrite markup trees.
+
+## Markup Visitor
+
+The core ``MarkupVisitor`` protocol provides the basis for transforming, walking, or rewriting a markup tree.
+
+```swift
+public protocol MarkupVisitor {
+    associatedtype Result
+}
+```
+
+Using its ``MarkupVisitor/Result`` type, you can transform a markup tree into anything: another markup tree, or perhaps a tree of XML or HTML elements. There are two included refinements of `MarkupVisitor` for common uses.
+
+## Markup Walker
+
+The first refinement of `MarkupVisitor`, ``MarkupWalker``, has an associated `Result` type of `Void`, so it's meant for summarizing or detecting aspects of a markup tree. If you wanted to append to a string as elements are visited, this might be a good tool for that.
+
+```swift
+import Markdown
+
+/// Counts `Link`s in a `Document`.
+struct LinkCounter: MarkupWalker {
+    var count = 0
+    mutating func visitLink(_ link: Link) {
+        if link.destination == "https://swift.org" {
+            count += 1
+        }
+        descendInto(link)
+    }
+}
+
+let source = "There are [two](https://swift.org) links to <https://swift.org> here."
+let document = Document(parsing: source)
+print(document.debugDescription())
+var linkCounter = LinkCounter()
+linkCounter.visit(document)
+print(linkCounter.count)
+// 2
+```
+
+## Markup Rewriter
+
+The second refinement, ``MarkupRewriter``, has an associated `Result` type of an optional ``Markup`` element, so it's meant to change or even remove elements from a markup tree. You can return `nil` to delete an element, or return another element to substitute in its place.
+
+```swift
+import Markdown
+
+/// Delete all **strong** elements in a markup tree.
+struct StrongDeleter: MarkupRewriter {
+    mutating func visitStrong(_ strong: Strong) -> Markup? {
+        return nil
+    }
+}
+
+let source = "Now you see me, **now you don't**"
+let document = Document(parsing: source)
+var strongDeleter = StrongDeleter()
+let newDocument = strongDeleter.visit(document)
+
+print(newDocument!.debugDescription())
+// Document
+// └─ Paragraph
+//    └─ Text "Now you see me, "
+```
+
+<!-- Copyright (c) 2021-2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/bin/update-gh-pages-documentation-site
+++ b/bin/update-gh-pages-documentation-site
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2022 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+#
+# Updates the GitHub Pages documentation site thats published from the 'docs' 
+# subdirectory in the 'gh-pages' branch of this repository.
+#
+# This script should be run by someone with commit access to the 'gh-pages' branch
+# at a regular frequency so that the documentation content on the GitHub Pages site
+# is up-to-date with the content in this repo.
+#
+
+set -eu
+
+# A `realpath` alternative using the default C implementation.
+filepath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+SWIFT_MARKDOWN_ROOT="$(dirname $(dirname $(filepath $0)))"
+
+# Set current directory to the repository root
+cd "$SWIFT_MARKDOWN_ROOT"
+
+# Use git worktree to checkout the gh-pages branch of this repository in a gh-pages sub-directory
+git fetch
+git worktree add --checkout gh-pages origin/gh-pages
+
+# Pretty print DocC JSON output so that it can be consistently diffed between commits
+export DOCC_JSON_PRETTYPRINT="YES"
+
+# Generate documentation for the 'Markdown' target and output it
+# to the /docs subdirectory in the gh-pages worktree directory.
+swift package \
+    --allow-writing-to-directory "$SWIFT_MARKDOWN_ROOT/gh-pages/docs" \
+    generate-documentation \
+    --target Markdown \
+    --disable-indexing \
+    --transform-for-static-hosting \
+    --hosting-base-path swift-markdown \
+    --output-path "$SWIFT_MARKDOWN_ROOT/gh-pages/docs"
+
+# Save the current commit we've just built documentation from in a variable
+CURRENT_COMMIT_HASH=`git rev-parse --short HEAD`
+
+# Commit and push our changes to the gh-pages branch
+cd gh-pages
+git add docs
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Documentation changes found. Committing the changes to the 'gh-pages' branch and pushing to origin."
+    git commit -m "Update GitHub Pages documentation site to $CURRENT_COMMIT_HASH"
+    git push origin HEAD:gh-pages
+else
+    # No changes found, nothing to commit.
+    echo "No documentation changes found."
+fi
+
+# Delete the git worktree we created
+cd ..
+git worktree remove gh-pages


### PR DESCRIPTION
## Summary

This sets the foundation for deploying Swift Markdown's documentation to GitHub pages.

- Adds the [Swift-DocC Plugin](https://github.com/apple/swift-docc-plugin) as a dependency of Swift-Markdown.
- Adds a script to simplify deployment of documentation to GitHub pages.

- Moves detailed documentation from the README into the DocC catalog.

After merging this PR, we should be able to prepare a `gh-pages` branch on the main `swift-markdown` repo with no content on it, run the `bin/update-gh-pages-documentation-site` script and have docs available.

## Dependencies

None.

## Testing

With Swift 5.6, run:

```shell
swift package --disable-sandbox preview-documentation --target Markdown
```

and confirm the Swift-DocC preview works as expected.


I've deployed the documentation to the GitHub pages site on my fork using the included script. Confirm the site behaves as expected here: https://ethan-kusters.github.io/swift-markdown/documentation/markdown/

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
