### PR TITLE
Remove extraneous print in test

### DIFF
--- a/Tests/MarkdownTests/Base/MarkupIdentifierTests.swift
+++ b/Tests/MarkdownTests/Base/MarkupIdentifierTests.swift
@@ -34,8 +34,6 @@ final class MarkupIdentifierTests: XCTestCase {
 
         let customBlock = buildCustomBlock(height: height, width: width)
 
-        print(customBlock.debugDescription(options: .printEverything))
-
         struct IDCounter: MarkupWalker {
             var id = 0
 


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

Removes extraneous print in `MarkupIdentifierTests.testChildIDsAreUnique()`.

## Dependencies

None.

## Testing

N/A, non functional change.

## Checklist

- ~[] Added tests~ N/A
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
