### PR TITLE
Enable library evolution via a conditional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /*.xcodeproj
 .swiftpm
 Package.resolved
+.enable-library-evolution

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,8 @@
 
 import PackageDescription
 import class Foundation.ProcessInfo
+import struct Foundation.URL
+import class Foundation.FileManager
 
 let cmarkPackageName = ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil ? "swift-cmark" : "swift-cmark-gfm"
 
@@ -30,7 +32,9 @@ let package = Package(
                 "CAtomic",
                 .product(name: "cmark-gfm", package: cmarkPackageName),
                 .product(name: "cmark-gfm-extensions", package: cmarkPackageName),
-            ]),
+            ],
+            swiftSettings: librarySwiftSettings()
+        ),
         .target(
             name: "markdown-tool",
             dependencies: [
@@ -44,6 +48,24 @@ let package = Package(
         .target(name: "CAtomic"),
     ]
 )
+
+func librarySwiftSettings() -> [SwiftSetting]? {
+    let manifestLocation = URL(fileURLWithPath: #filePath)
+
+    let enableLibraryEvolutionFileLocation = manifestLocation
+        .deletingLastPathComponent()
+        .appendingPathComponent(".enable-library-evolution")
+    
+    // If there is a `.enable-library-evolution` file as a sibling of this package manifest
+    // build libraries with library evolution enabled.
+    if FileManager.default.fileExists(atPath: enableLibraryEvolutionFileLocation.path) {
+        return [
+            .unsafeFlags(["-enable-library-evolution"])
+        ]
+    } else {
+        return []
+    }
+}
 
 // If the `SWIFTCI_USE_LOCAL_DEPS` environment variable is set,
 // we're building in the Swift.org CI system alongside other projects in the Swift toolchain and

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -13,6 +13,8 @@
 
 import PackageDescription
 import class Foundation.ProcessInfo
+import struct Foundation.URL
+import class Foundation.FileManager
 
 let cmarkPackageName = ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil ? "swift-cmark" : "swift-cmark-gfm"
 
@@ -30,7 +32,9 @@ let package = Package(
                 "CAtomic",
                 .product(name: "cmark-gfm", package: cmarkPackageName),
                 .product(name: "cmark-gfm-extensions", package: cmarkPackageName),
-            ]),
+            ],
+            swiftSettings: librarySwiftSettings()
+        ),
         .executableTarget(
             name: "markdown-tool",
             dependencies: [
@@ -44,6 +48,24 @@ let package = Package(
         .target(name: "CAtomic"),
     ]
 )
+
+func librarySwiftSettings() -> [SwiftSetting]? {
+    let manifestLocation = URL(fileURLWithPath: #filePath)
+
+    let enableLibraryEvolutionFileLocation = manifestLocation
+        .deletingLastPathComponent()
+        .appendingPathComponent(".enable-library-evolution")
+    
+    // If there is a `.enable-library-evolution` file as a sibling of this package manifest
+    // build libraries with library evolution enabled.
+    if FileManager.default.fileExists(atPath: enableLibraryEvolutionFileLocation.path) {
+        return [
+            .unsafeFlags(["-enable-library-evolution"])
+        ]
+    } else {
+        return []
+    }
+}
 
 // If the `SWIFTCI_USE_LOCAL_DEPS` environment variable is set,
 // we're building in the Swift.org CI system alongside other projects in the Swift toolchain and


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://91237377

## Summary

Adds support for building the `Markdown` library with library evolution enabled. This is disabled by default, and to enable the behavior, add an `.enable-library-evolution` file at the root of your checkout.

## Dependencies

None.

## Testing

Verify that `Markdown` is built with library evolution enabled by inspecting build logs if and only if the checkout has an `.enable-library-evolution` file at its root.

## Checklist

- ~[ ] Added tests~ N/A
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary