### PR TITLE
Update swift-cmark dependency to `release/5.7-gfm`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-cmark.git", .branch("gfm")),
+        .package(url: "https://github.com/apple/swift-cmark.git", .branch("release/5.7-gfm")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
     ]
 } else {

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -51,7 +51,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-cmark.git", .branch("gfm")),
+        .package(url: "https://github.com/apple/swift-cmark.git", .branch("release/5.7-gfm")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
     ]
     


### PR DESCRIPTION
## Summary

This is effectively a non-functional change since `gfm` and `release/5.7-gfm` currently point to the same commit.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ NFC
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
