### PR TITLE
Improve performance of `Markup.child(at:)`

### DIFF
--- a/Sources/Markdown/Base/Markup.swift
+++ b/Sources/Markdown/Base/Markup.swift
@@ -183,14 +183,16 @@ extension Markup {
 
     /// Returns the child at the given position if it is within the bounds of `children.indices`.
     ///
-    /// - Complexity: `O(childCount)`
+    /// - Complexity: `O(1)`
     public func child(at position: Int) -> Markup? {
         precondition(position >= 0, "Cannot retrieve a child at negative index: \(position)")
-        guard position <= raw.markup.childCount else {
+        guard position < raw.markup.childCount else {
             return nil
         }
-        var iterator = children.dropFirst(position).makeIterator()
-        return iterator.next()
+        let rawChild = raw.markup.child(at: position)
+        let absoluteRawMarkup = AbsoluteRawMarkup(markup: rawChild, metadata: raw.metadata.firstChild())
+        let data = _MarkupData(absoluteRawMarkup, parent: self)
+        return makeMarkup(data)
     }
 
     /// Traverse this markup tree by descending into the child at the index of each path element, returning `nil` if there is no child at that index or if the expected type for that path element doesn't match.


### PR DESCRIPTION
## Summary

While investigating general performance improvements in Swift-DocC for:

- apple/swift-docc#166

I found that Swift-DocC was spending a lot of time creating iterators while rewriting markup elements in Swift-Markdown code. This PR is a refactoring of the `Markup.child(at:)` method to improve performance from `O(childCount)` to `O(1)`.

The change here is to just pull in the code from [`MarkupChildren.Iterator`](https://github.com/apple/swift-markdown/blob/2ba1ed5/Sources/Markdown/Base/MarkupChildren.swift#L26) that was already being used:

```swift
public mutating func next() -> Markup? {
    let index = childMetadata.indexInParent
    guard index < parent.childCount else {
        return nil
    }
    let rawChild = parent.raw.markup.child(at: index)
    let absoluteRawChild = AbsoluteRawMarkup(markup: rawChild, metadata: childMetadata)
    let data = _MarkupData(absoluteRawChild, parent: parent)
    childMetadata = childMetadata.nextSibling(from: rawChild)
    return makeMarkup(data)
}
```

and call `RawMarkup.child(at:)` directly in the `Markup.child(at:)` method instead of wrapping those calls in the creation of the markup iterator.

## Testing

Existing tests that exercise `Markup.child(at:)` continue to pass as does the Swift-DocC test suite when using this change.

Since this is a 1-1 refactoring I didn't see an opportunity for new tests but happy to add any that would be helpful here.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
