### PR TITLE
Improve performance of `Markup.child(at:)` method while still accurately tracking metadata

### DIFF
--- a/Sources/Markdown/Base/Markup.swift
+++ b/Sources/Markdown/Base/Markup.swift
@@ -186,11 +186,22 @@ extension Markup {
     /// - Complexity: `O(childCount)`
     public func child(at position: Int) -> Markup? {
         precondition(position >= 0, "Cannot retrieve a child at negative index: \(position)")
-        guard position <= raw.markup.childCount else {
+        guard position < raw.markup.childCount else {
             return nil
         }
-        var iterator = children.dropFirst(position).makeIterator()
-        return iterator.next()
+        
+        let childMetadata: MarkupMetadata
+        if position == 0 {
+            childMetadata = raw.metadata.firstChild()
+        } else {
+            let siblings = (0..<position).map(raw.markup.child(at:))
+            childMetadata = raw.metadata.firstChild().nextSibling(from: siblings)
+        }
+        
+        let rawChild = raw.markup.child(at: position)
+        let absoluteRawMarkup = AbsoluteRawMarkup(markup: rawChild, metadata: childMetadata)
+        let data = _MarkupData(absoluteRawMarkup, parent: self)
+        return makeMarkup(data)
     }
 
     /// Traverse this markup tree by descending into the child at the index of each path element, returning `nil` if there is no child at that index or if the expected type for that path element doesn't match.

--- a/Sources/Markdown/Base/Markup.swift
+++ b/Sources/Markdown/Base/Markup.swift
@@ -194,8 +194,17 @@ extension Markup {
         if position == 0 {
             childMetadata = raw.metadata.firstChild()
         } else {
-            let siblings = (0..<position).map(raw.markup.child(at:))
-            childMetadata = raw.metadata.firstChild().nextSibling(from: siblings)
+            let siblingSubtreeCount = (0..<position).reduce(0) { partialSubtreeCount, currentPosition in
+                return partialSubtreeCount + raw.markup.child(at: currentPosition).subtreeCount
+            }
+            
+            let firstChildID = raw.metadata.firstChild().id
+            let childID = MarkupIdentifier(
+                rootId: firstChildID.rootId,
+                childId: firstChildID.childId + siblingSubtreeCount
+            )
+            
+            childMetadata = MarkupMetadata(id: childID, indexInParent: indexInParent + position)
         }
         
         let rawChild = raw.markup.child(at: position)

--- a/Sources/Markdown/Base/MarkupData.swift
+++ b/Sources/Markdown/Base/MarkupData.swift
@@ -29,12 +29,6 @@ struct MarkupIdentifier: Equatable {
         return .init(rootId: rootId, childId: childId + raw.subtreeCount)
     }
     
-    /// Returns the identifier for the next sibling of the given raw elements.
-    func nextSibling(from raw: [RawMarkup]) -> MarkupIdentifier {
-        let subtreeCount = raw.lazy.map(\.subtreeCount).reduce(0, +)
-        return .init(rootId: rootId, childId: childId + subtreeCount)
-    }
-
     /// Returns the identifier for the previous sibling of the given raw element.
     ///
     /// - Note: This method assumes that this identifier belongs to `raw`.
@@ -78,11 +72,6 @@ struct MarkupMetadata {
         return MarkupMetadata(id: id.nextSibling(from: raw), indexInParent: indexInParent + 1)
     }
     
-    /// Returns metadata for the next sibling of the given raw elements.
-    func nextSibling(from raw: [RawMarkup]) -> MarkupMetadata {
-        return MarkupMetadata(id: id.nextSibling(from: raw), indexInParent: indexInParent + raw.count)
-    }
-
     /// Returns metadata for the previous sibling of the given raw element.
     ///
     /// - Note: This method assumes that this metadata belongs to `raw`.

--- a/Sources/Markdown/Base/MarkupData.swift
+++ b/Sources/Markdown/Base/MarkupData.swift
@@ -28,7 +28,7 @@ struct MarkupIdentifier: Equatable {
     func nextSibling(from raw: RawMarkup) -> MarkupIdentifier {
         return .init(rootId: rootId, childId: childId + raw.subtreeCount)
     }
-    
+
     /// Returns the identifier for the previous sibling of the given raw element.
     ///
     /// - Note: This method assumes that this identifier belongs to `raw`.
@@ -71,7 +71,7 @@ struct MarkupMetadata {
     func nextSibling(from raw: RawMarkup) -> MarkupMetadata {
         return MarkupMetadata(id: id.nextSibling(from: raw), indexInParent: indexInParent + 1)
     }
-    
+
     /// Returns metadata for the previous sibling of the given raw element.
     ///
     /// - Note: This method assumes that this metadata belongs to `raw`.

--- a/Sources/Markdown/Base/MarkupData.swift
+++ b/Sources/Markdown/Base/MarkupData.swift
@@ -28,6 +28,12 @@ struct MarkupIdentifier: Equatable {
     func nextSibling(from raw: RawMarkup) -> MarkupIdentifier {
         return .init(rootId: rootId, childId: childId + raw.subtreeCount)
     }
+    
+    /// Returns the identifier for the next sibling of the given raw elements.
+    func nextSibling(from raw: [RawMarkup]) -> MarkupIdentifier {
+        let subtreeCount = raw.lazy.map(\.subtreeCount).reduce(0, +)
+        return .init(rootId: rootId, childId: childId + subtreeCount)
+    }
 
     /// Returns the identifier for the previous sibling of the given raw element.
     ///
@@ -70,6 +76,11 @@ struct MarkupMetadata {
     /// - Note: This method assumes that this metadata belongs to `raw`.
     func nextSibling(from raw: RawMarkup) -> MarkupMetadata {
         return MarkupMetadata(id: id.nextSibling(from: raw), indexInParent: indexInParent + 1)
+    }
+    
+    /// Returns metadata for the next sibling of the given raw elements.
+    func nextSibling(from raw: [RawMarkup]) -> MarkupMetadata {
+        return MarkupMetadata(id: id.nextSibling(from: raw), indexInParent: indexInParent + raw.count)
     }
 
     /// Returns metadata for the previous sibling of the given raw element.

--- a/Tests/MarkdownTests/Base/MarkupTests.swift
+++ b/Tests/MarkdownTests/Base/MarkupTests.swift
@@ -344,6 +344,20 @@ final class MarkupTests: XCTestCase {
             
             XCTAssertEqual(indexedChildMetadata.id, sequencedChildMetadata.id)
             XCTAssertEqual(indexedChildMetadata.indexInParent, sequencedChildMetadata.indexInParent)
+            XCTAssertEqual(indexedChildMetadata.indexInParent, index)
+        }
+    }
+    
+    func testChildAtPositionHasCorrectDataID() throws {
+        let source = "This is a [*link*](github.com). And some **bold** and *italic* text."
+        
+        let document = Document(parsing: source)
+        let paragraph = try XCTUnwrap(document.child(at: 0) as? Paragraph)
+        
+        for (index, sequencedChild) in paragraph.children.enumerated() {
+            let indexedChild = try XCTUnwrap(paragraph.child(at: index))
+            
+            XCTAssertEqual(indexedChild._data.id, sequencedChild._data.id)
         }
     }
     

--- a/Tests/MarkdownTests/Base/MarkupTests.swift
+++ b/Tests/MarkdownTests/Base/MarkupTests.swift
@@ -283,4 +283,79 @@ final class MarkupTests: XCTestCase {
             )!.debugDescription()
         )
     }
+    
+    func testChildAtPositionHasCorrectType() throws {
+        let source = "This is a [*link*](github.com). And some **bold** and *italic* text."
+        
+        /*
+         Document
+         └─ Paragraph
+        */
+        let document = Document(parsing: source)
+        let paragraph = try XCTUnwrap(document.child(at: 0))
+        assertEqualType(paragraph, Paragraph.self)
+        
+        /*
+            ├─ Text "This is a "
+            ├─ Link destination: "github.com"
+            │  └─ Emphasis
+            │     └─ Text "link"
+         
+        */
+        assertEqualType(paragraph.child(at: 0), Text.self)
+        assertEqualType(paragraph.child(at: 1), Link.self)
+        assertEqualType(paragraph.child(at: 1)?.child(at: 0), Emphasis.self)
+        assertEqualType(paragraph.child(at: 1)?.child(at: 0)?.child(at: 0), Text.self)
+        
+        /*
+            ├─ Text ". And some "
+            ├─ Strong
+            │  └─ Text "bold"
+        */
+        assertEqualType(paragraph.child(at: 2), Text.self)
+        assertEqualType(paragraph.child(at: 3), Strong.self)
+        assertEqualType(paragraph.child(at: 3)?.child(at: 0), Text.self)
+        
+        /*
+            ├─ Text " and "
+            ├─ Emphasis
+            │  └─ Text "italic"
+            └─ Text " text."
+        */
+        assertEqualType(paragraph.child(at: 4), Text.self)
+        assertEqualType(paragraph.child(at: 5), Emphasis.self)
+        assertEqualType(paragraph.child(at: 5)?.child(at: 0), Text.self)
+        assertEqualType(paragraph.child(at: 6), Text.self)
+        
+        XCTAssertNil(paragraph.child(at: 7))
+    }
+    
+    func testChildAtPositionHasCorrectMetadata() throws {
+        let source = "This is a [*link*](github.com). And some **bold** and *italic* text."
+        
+        let document = Document(parsing: source)
+        let paragraph = try XCTUnwrap(document.child(at: 0) as? Paragraph)
+        
+        for (index, sequencedChild) in paragraph.children.enumerated() {
+            let indexedChild = try XCTUnwrap(paragraph.child(at: index))
+            
+            let indexedChildMetadata = indexedChild.raw.metadata
+            let sequencedChildMetadata = sequencedChild.raw.metadata
+            
+            XCTAssertEqual(indexedChildMetadata.id, sequencedChildMetadata.id)
+            XCTAssertEqual(indexedChildMetadata.indexInParent, sequencedChildMetadata.indexInParent)
+        }
+    }
+    
+    func assertEqualType<FirstType, SecondType>(
+        _ first: FirstType,
+        _ second: SecondType.Type,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        guard first is SecondType else {
+            XCTFail("'\(type(of: first))' is not expected type '\(second)'", file: file, line: line)
+            return
+        }
+    }
 }


### PR DESCRIPTION
## Summary

While investigating general performance improvements in Swift-DocC for:

- https://github.com/apple/swift-docc/pull/166

I found that Swift-DocC was spending a lot of time creating iterators while rewriting markup elements in Swift-Markdown code using `MarkupRewriter`s. This PR is a refactoring of the `Markup.child(at:)` method to improve performance.

I put up a PR with a similar change in #36 where @bitjammer pointed out that I was incorrectly tracking metadata for child elements. This is a second iteration on that PR that resolves that issue and adds a test to catch the issue I missed before. It appears to have the same performance win as the original PR when testing with the Swift-DocC performance suite.

## Testing

I added tests that confirm the metadata returned for child elements via the new `child(at:)` implementation is the same as the metadata for child elements returned via the existing sequence implementation. Swift-Markdown and Swift-DocC's existing tests continue to pass with this change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
