### PR TITLE
Correctly set `indexInParent` in `Markup.child(at:)`

### DIFF
--- a/Sources/Markdown/Base/Markup.swift
+++ b/Sources/Markdown/Base/Markup.swift
@@ -204,7 +204,7 @@ extension Markup {
                 childId: firstChildID.childId + siblingSubtreeCount
             )
             
-            childMetadata = MarkupMetadata(id: childID, indexInParent: indexInParent + position)
+            childMetadata = MarkupMetadata(id: childID, indexInParent: position)
         }
         
         let rawChild = raw.markup.child(at: position)

--- a/Tests/MarkdownTests/Base/MarkupTests.swift
+++ b/Tests/MarkdownTests/Base/MarkupTests.swift
@@ -348,6 +348,25 @@ final class MarkupTests: XCTestCase {
         }
     }
     
+    func testNestedChildAtPositionHasCorrectMetadata() throws {
+        let source = "This is some **bold** and *italic* text and a [multi-formatted *link* **to** `github`](github.com)."
+        
+        let document = Document(parsing: source)
+        let link = try XCTUnwrap(document.child(at: 0)?.child(at: 5) as? Link)
+        XCTAssertEqual(link.indexInParent, 5)
+        
+        for (index, sequencedChild) in link.children.enumerated() {
+            let indexedChild = try XCTUnwrap(link.child(at: index))
+            
+            let indexedChildMetadata = indexedChild.raw.metadata
+            let sequencedChildMetadata = sequencedChild.raw.metadata
+            
+            XCTAssertEqual(indexedChildMetadata.id, sequencedChildMetadata.id)
+            XCTAssertEqual(indexedChildMetadata.indexInParent, sequencedChildMetadata.indexInParent)
+            XCTAssertEqual(indexedChildMetadata.indexInParent, index)
+        }
+    }
+    
     func testChildAtPositionHasCorrectDataID() throws {
         let source = "This is a [*link*](github.com). And some **bold** and *italic* text."
         
@@ -356,6 +375,19 @@ final class MarkupTests: XCTestCase {
         
         for (index, sequencedChild) in paragraph.children.enumerated() {
             let indexedChild = try XCTUnwrap(paragraph.child(at: index))
+            
+            XCTAssertEqual(indexedChild._data.id, sequencedChild._data.id)
+        }
+    }
+    
+    func testNestedChildAtPositionHasCorrectDataID() throws {
+        let source = "This is some **bold** and *italic* text and a [multi-formatted *link* **to** `github`](github.com)."
+        
+        let document = Document(parsing: source)
+        let link = try XCTUnwrap(document.child(at: 0)?.child(at: 5) as? Link)
+        
+        for (index, sequencedChild) in link.children.enumerated() {
+            let indexedChild = try XCTUnwrap(link.child(at: index))
             
             XCTAssertEqual(indexedChild._data.id, sequencedChild._data.id)
         }


### PR DESCRIPTION
## Summary

This fixes a regression introduced with #44 where `Markup.child(at:)` began returning markup with incorrect metadata resulting in out-of-bounds errors.

## Testing

Existing and new unit tests pass. I've also confirmed that Swift-DocC's test suite is now passing with this change (it fails with what's currently on `main`).

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
