### PR TITLE
[5.7] Improve performance of `Markup.child(at:)` method

### DIFF
--- a/Sources/Markdown/Base/Markup.swift
+++ b/Sources/Markdown/Base/Markup.swift
@@ -204,7 +204,7 @@ extension Markup {
                 childId: firstChildID.childId + siblingSubtreeCount
             )
             
-            childMetadata = MarkupMetadata(id: childID, indexInParent: indexInParent + position)
+            childMetadata = MarkupMetadata(id: childID, indexInParent: position)
         }
         
         let rawChild = raw.markup.child(at: position)

--- a/Sources/Markdown/Base/Markup.swift
+++ b/Sources/Markdown/Base/Markup.swift
@@ -186,11 +186,31 @@ extension Markup {
     /// - Complexity: `O(childCount)`
     public func child(at position: Int) -> Markup? {
         precondition(position >= 0, "Cannot retrieve a child at negative index: \(position)")
-        guard position <= raw.markup.childCount else {
+        guard position < raw.markup.childCount else {
             return nil
         }
-        var iterator = children.dropFirst(position).makeIterator()
-        return iterator.next()
+        
+        let childMetadata: MarkupMetadata
+        if position == 0 {
+            childMetadata = raw.metadata.firstChild()
+        } else {
+            let siblingSubtreeCount = (0..<position).reduce(0) { partialSubtreeCount, currentPosition in
+                return partialSubtreeCount + raw.markup.child(at: currentPosition).subtreeCount
+            }
+            
+            let firstChildID = raw.metadata.firstChild().id
+            let childID = MarkupIdentifier(
+                rootId: firstChildID.rootId,
+                childId: firstChildID.childId + siblingSubtreeCount
+            )
+            
+            childMetadata = MarkupMetadata(id: childID, indexInParent: indexInParent + position)
+        }
+        
+        let rawChild = raw.markup.child(at: position)
+        let absoluteRawMarkup = AbsoluteRawMarkup(markup: rawChild, metadata: childMetadata)
+        let data = _MarkupData(absoluteRawMarkup, parent: self)
+        return makeMarkup(data)
     }
 
     /// Traverse this markup tree by descending into the child at the index of each path element, returning `nil` if there is no child at that index or if the expected type for that path element doesn't match.

--- a/Tests/MarkdownTests/Base/MarkupTests.swift
+++ b/Tests/MarkdownTests/Base/MarkupTests.swift
@@ -348,6 +348,25 @@ final class MarkupTests: XCTestCase {
         }
     }
     
+    func testNestedChildAtPositionHasCorrectMetadata() throws {
+        let source = "This is some **bold** and *italic* text and a [multi-formatted *link* **to** `github`](github.com)."
+        
+        let document = Document(parsing: source)
+        let link = try XCTUnwrap(document.child(at: 0)?.child(at: 5) as? Link)
+        XCTAssertEqual(link.indexInParent, 5)
+        
+        for (index, sequencedChild) in link.children.enumerated() {
+            let indexedChild = try XCTUnwrap(link.child(at: index))
+            
+            let indexedChildMetadata = indexedChild.raw.metadata
+            let sequencedChildMetadata = sequencedChild.raw.metadata
+            
+            XCTAssertEqual(indexedChildMetadata.id, sequencedChildMetadata.id)
+            XCTAssertEqual(indexedChildMetadata.indexInParent, sequencedChildMetadata.indexInParent)
+            XCTAssertEqual(indexedChildMetadata.indexInParent, index)
+        }
+    }
+    
     func testChildAtPositionHasCorrectDataID() throws {
         let source = "This is a [*link*](github.com). And some **bold** and *italic* text."
         
@@ -356,6 +375,19 @@ final class MarkupTests: XCTestCase {
         
         for (index, sequencedChild) in paragraph.children.enumerated() {
             let indexedChild = try XCTUnwrap(paragraph.child(at: index))
+            
+            XCTAssertEqual(indexedChild._data.id, sequencedChild._data.id)
+        }
+    }
+    
+    func testNestedChildAtPositionHasCorrectDataID() throws {
+        let source = "This is some **bold** and *italic* text and a [multi-formatted *link* **to** `github`](github.com)."
+        
+        let document = Document(parsing: source)
+        let link = try XCTUnwrap(document.child(at: 0)?.child(at: 5) as? Link)
+        
+        for (index, sequencedChild) in link.children.enumerated() {
+            let indexedChild = try XCTUnwrap(link.child(at: index))
             
             XCTAssertEqual(indexedChild._data.id, sequencedChild._data.id)
         }


### PR DESCRIPTION
- **Rationale:** Provides a ~7% performance improvement for the overall convert time of Swift-DocC which allows for landing new functionality in Swift-DocC's 5.7 release without regressing overall performance.
- **Risk:** Low
- **Risk Detail:** Minor, targeted change that is covered by a test.
- **Reward:** Medium
- **Reward Details:** Allows landing of new functionality in Swift-DocC's 5.7 release without regressing overall performance ([swift-docc#166](https://github.com/apple/swift-docc/pull/166)).
- **Original PR:** https://github.com/apple/swift-markdown/pull/44
- **Code Reviewed By:** @bitjammer 
- **Testing Details:** Added unit tests to ensure that the new implementation of `Markup.child(at:)` matches the previous behavior.