### PR TITLE
use "cmark" instead of "swift-cmark-gfm" in the toolchain build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@
 import PackageDescription
 import class Foundation.ProcessInfo
 
-let cmarkPackageName = ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil ? "swift-cmark" : "swift-cmark-gfm"
+let cmarkPackageName = ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil ? "swift-cmark" : "cmark"
 
 let package = Package(
     name: "swift-markdown",
@@ -57,7 +57,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
 } else {
     // Building in the Swift.org CI system, so rely on local versions of dependencies.
     package.dependencies += [
-        .package(path: "../swift-cmark-gfm"),
+        .package(path: "../cmark"),
         .package(path: "../swift-argument-parser"),
     ]
 }

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -14,7 +14,7 @@
 import PackageDescription
 import class Foundation.ProcessInfo
 
-let cmarkPackageName = ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil ? "swift-cmark" : "swift-cmark-gfm"
+let cmarkPackageName = ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil ? "swift-cmark" : "cmark"
 
 let package = Package(
     name: "swift-markdown",
@@ -64,7 +64,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
 } else {
     // Building in the Swift.org CI system, so rely on local versions of dependencies.
     package.dependencies += [
-        .package(path: "../swift-cmark-gfm"),
+        .package(path: "../cmark"),
         .package(path: "../swift-argument-parser"),
     ]
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://90461704

## Summary

The Swift compiler is now using the `gfm` branch of `swift-cmark`, so the `cmark` directory of the build structure is using the same branch as `swift-cmark-gfm`. This PR updates swift-markdown's package files to point to the same repository directory that the compiler is using, so that the extra clone can be cleaned up.

## Dependencies

None ([The required work](https://github.com/apple/swift/pull/40188) landed in apple/swift on May 2)

## Testing

No behavior change in swift-markdown.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
