### PR TITLE
Update SourceLocation doc and add test case

### DIFF
--- a/Sources/Markdown/Infrastructure/SourceLocation.swift
+++ b/Sources/Markdown/Infrastructure/SourceLocation.swift
@@ -25,7 +25,7 @@ public struct SourceLocation: Hashable, CustomStringConvertible, Comparable {
     /// The line number of the location.
     public var line: Int
 
-    /// The number of Unicode code units from the start of the line to the character at this source location.
+    /// The number of bytes in UTF-8 encoding from the start of the line to the character at this source location.
     public var column: Int
 
     /// The source file for which this location applies, if it came from an accessible location.

--- a/Tests/MarkdownTests/Infrastructure/SourceLoacationTests.swift
+++ b/Tests/MarkdownTests/Infrastructure/SourceLoacationTests.swift
@@ -1,0 +1,34 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+@testable import Markdown
+import XCTest
+
+class SourceLoacationTests: XCTestCase {
+    func testNonAsciiCharacterColumn() throws {
+        func helper(source: String) throws {
+            print("source:: \(source)")
+            print("String.count: \(source.count)")
+            print("NSString.length: \((source as NSString).length)")
+            print("unicodeScalars.count: \(source.unicodeScalars.count)")
+            print("utf8.count: \(source.utf8.count)")
+
+            let document = Document(parsing: source)
+            let range = try XCTUnwrap(document.range)
+            print("range: \(range)")
+            XCTAssertEqual(range.upperBound.column - 1, source.utf8.count)
+        }
+
+        // Emoji
+        try helper(source: "🇺🇳")
+        // CJK Character
+        try helper(source: "叶")
+    }
+}

--- a/Tests/MarkdownTests/Infrastructure/SourceLoacationTests.swift
+++ b/Tests/MarkdownTests/Infrastructure/SourceLoacationTests.swift
@@ -13,22 +13,15 @@ import XCTest
 
 class SourceLoacationTests: XCTestCase {
     func testNonAsciiCharacterColumn() throws {
-        func helper(source: String) throws {
-            print("source:: \(source)")
-            print("String.count: \(source.count)")
-            print("NSString.length: \((source as NSString).length)")
-            print("unicodeScalars.count: \(source.unicodeScalars.count)")
-            print("utf8.count: \(source.utf8.count)")
-
-            let document = Document(parsing: source)
+        func assertColumnNumberAssumesUTF8Encoding(text: String) throws {
+            let document = Document(parsing: text)
             let range = try XCTUnwrap(document.range)
-            print("range: \(range)")
-            XCTAssertEqual(range.upperBound.column - 1, source.utf8.count)
+            XCTAssertEqual(range.upperBound.column - 1, text.utf8.count)
         }
 
         // Emoji
-        try helper(source: "🇺🇳")
+        try assertColumnNumberAssumesUTF8Encoding(text: "🇺🇳")
         // CJK Character
-        try helper(source: "叶")
+        try assertColumnNumberAssumesUTF8Encoding(text: "叶")
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

Close #37

## Testing

```
Test Case '-[MarkdownTests.SourceLoacationTests testNonAsciiCharacterColumn]' started.
source:: 🇺🇳
String.count: 1
NSString.length: 4
unicodeScalars.count: 2
utf8.count: 8
range: 1:1..<1:9
source:: 叶
String.count: 1
NSString.length: 1
unicodeScalars.count: 1
utf8.count: 3
range: 1:1..<1:4
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
