### PR TITLE
Improve efficiency of Aside.Kind.init(rawValue:)

### DIFF
--- a/Sources/Markdown/Interpretive Nodes/Aside.swift
+++ b/Sources/Markdown/Interpretive Nodes/Aside.swift
@@ -93,12 +93,10 @@ public struct Aside {
         case `throws` = "Throws"
 
         public init?(rawValue: String) {
-            // Allow lowercase aside prefixes to match.
-            let casesAndLowercasedRawValues = Kind.allCases.map { (kind: $0, rawValue: $0.rawValue.lowercased() )}
-            guard let matchingCaseAndRawValue = casesAndLowercasedRawValues.first(where: { $0.rawValue == rawValue.lowercased() }) else {
+            guard let kind = Kind.allCases.first(where: { $0.rawValue.caseInsensitiveCompare(rawValue) == .orderedSame }) else {
                 return nil
             }
-            self = matchingCaseAndRawValue.kind
+            self = kind
         }
     }
 


### PR DESCRIPTION
Bug/issue #, if applicable: 

Close #48

## Summary

Use String.caseInsensitiveCompare to replace the lowercase compute logic.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
