### PR TITLE
Add a new Parse Option to disable Smart Opts during parsing

### DIFF
--- a/Sources/Markdown/Parser/CommonMarkConverter.swift
+++ b/Sources/Markdown/Parser/CommonMarkConverter.swift
@@ -577,7 +577,11 @@ struct MarkupParser {
 
     static func parseString(_ string: String, source: URL?, options: ParseOptions) -> Document {
         cmark_gfm_core_extensions_ensure_registered()
-        let parser = cmark_parser_new(CMARK_OPT_SMART)
+        
+        let parser = cmark_parser_new(options.contains(.disableSmartOpts)
+                                      ? CMARK_OPT_DEFAULT
+                                      : CMARK_OPT_SMART)
+        
         cmark_parser_attach_syntax_extension(parser, cmark_find_syntax_extension("table"))
         cmark_parser_attach_syntax_extension(parser, cmark_find_syntax_extension("strikethrough"))
         cmark_parser_attach_syntax_extension(parser, cmark_find_syntax_extension("tasklist"))

--- a/Sources/Markdown/Parser/ParseOptions.swift
+++ b/Sources/Markdown/Parser/ParseOptions.swift
@@ -21,5 +21,8 @@ public struct ParseOptions: OptionSet {
 
     /// Enable interpretation of symbol links from inline code spans surrounded by two backticks.
     public static let parseSymbolLinks = ParseOptions(rawValue: 1 << 1)
+    
+    /// Disable converting straight quotes to curly, --- to em dashes, -- to en dashes during parsing
+    public static let disableSmartOpts = ParseOptions(rawValue: 1 << 2)
 }
 

--- a/Tests/MarkdownTests/Parsing/SourceURLTests.swift
+++ b/Tests/MarkdownTests/Parsing/SourceURLTests.swift
@@ -75,4 +75,26 @@ class SourceURLTests: XCTestCase {
         """
         XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
     }
+    
+    func testParseString_SmartOpts() {
+        let text = "The iPod (2001--2022) changed the way people listened and interacted with music---it'll forever be in our hearts!"
+        
+        // With Smart Opts
+        let smartOptsEnabledDocument = Document(parsing: text, options: [])
+        let smartOptsEnabledExpectedDump = """
+        Document
+        └─ Paragraph
+           └─ Text \"The iPod (2001–2022) changed the way people listened and interacted with music—it’ll forever be in our hearts!\"
+        """
+        XCTAssertEqual(smartOptsEnabledExpectedDump, smartOptsEnabledDocument.debugDescription())
+
+        // Without Smart Opts
+        let smartOptsDisabledDocument = Document(parsing: text, options: [.disableSmartOpts])
+        let smartOptsDisabledExpectedDump = """
+        Document
+        └─ Paragraph
+           └─ Text \"The iPod (2001--2022) changed the way people listened and interacted with music---it'll forever be in our hearts!\"
+        """
+        XCTAssertEqual(smartOptsDisabledExpectedDump, smartOptsDisabledDocument.debugDescription())
+    }
 }


### PR DESCRIPTION
## Summary

The parser, currently, automatically converts straight quotes to curly, --- to em dashes, and -- to en dashes during the parsing process. We did not expect the parser to actually change the text source and it was causing our UI Tests to fail. This PR adds the ability to disable this conversion during the parsing process. I went with a "disable" approach so that if this change is merged in, it won't affect users already using this framework, as nothing will change unless they pass in the Parse Option.

## PR Overview
* Added a new Parse Option to disable Smart Opts during parsing. I.e,
    * disable converting straight quotes to curly, --- to em dashes, -- to en dashes during parsing
* Updated parser initialization to use the defaults when the options contain `.disableSmartOpts`
* Added a unit test to verify `.disableSmartOpts` works as expected

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
