### PR TITLE
Add simple snippets support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /*.xcodeproj
 .swiftpm
 Package.resolved
+.vscode

--- a/Snippets/Parsing/Explanation.md
+++ b/Snippets/Parsing/Explanation.md
@@ -1,0 +1,1 @@
+Examples on how to use Swift Markdown Framework to parse the Markdown String into Swift object

--- a/Snippets/Parsing/ParseFile.swift
+++ b/Snippets/Parsing/ParseFile.swift
@@ -1,0 +1,19 @@
+//! Example on how to parse Markdown from file
+import Markdown
+import Foundation
+
+// MARK: Hide
+let tempDirecotry = FileManager.default.temporaryDirectory
+let testFile = tempDirecotry.appendingPathComponent("Test.md")
+let testData = """
+1. Hello
+2. World
+""".data(using: .utf8)!
+try testData.write(to: testFile)
+// MARK: Show
+guard let source = try? String(contentsOf: testFile) else {
+    fatalError("Unable to get the contents of the Test.md file")
+}
+let everythingDocument = Document(parsing: source)
+let document = Document(parsing: source)
+print(document.debugDescription(options: [.printEverything]))

--- a/Snippets/Parsing/ParseString.swift
+++ b/Snippets/Parsing/ParseString.swift
@@ -1,0 +1,6 @@
+//! Example on how to parse Markdown from string
+import Markdown
+
+let source = "Hello world"
+let document = Document(parsing: source)
+print(document.debugDescription(options: [.printEverything]))

--- a/Snippets/Visiting/Explanation.md
+++ b/Snippets/Visiting/Explanation.md
@@ -1,0 +1,1 @@
+Examples on how to use Swift Markdown Framework to visit the Markdown object

--- a/Snippets/Visiting/MarkupCounter.swift
+++ b/Snippets/Visiting/MarkupCounter.swift
@@ -1,0 +1,43 @@
+//! Define a MarkupCounter struct to count the Text and UnorderedList count of the Markup Object 
+import Markdown
+struct MarkupCounter: MarkupWalker {
+    private var textCount = 0
+    private var unorderedListCount = 0
+    private var unorderedListItemsCount = 0
+
+    // MARK: Hide
+    var result: String {
+        """
+        The Markup has:
+        \(textCount) Text elements
+        \(unorderedListCount) UnorderedList elements with a total of \(unorderedListItemsCount) items
+        """
+    }
+    // MARK: Show
+
+    mutating func visitText(_ text: Text) -> () {
+        print("Visiting Text Element: \(text.string)\n")
+        textCount += 1
+    }
+    mutating func visitUnorderedList(_ unorderedList: UnorderedList) -> () {
+        print("Visiting UnorderedList Element: \(unorderedList.format())\n")
+        unorderedListCount += 1
+        unorderedListItemsCount += unorderedList.childCount
+    }
+}
+
+let source = """
+Hello
+
+- Item 1
+- Item 2
+
+world
+
+- Item 3
+"""
+let document = Document(parsing: source)
+
+var dumper = MarkupCounter()
+dumper.visit(document)
+print(dumper.result)


### PR DESCRIPTION
- Add simple snippets support
- Add .vscode to .gitignore file

Bug/issue #, if applicable: 

Close #52 

## Summary

Add Swift Snippets Support for swift-markdown package

See more discussion on this forum post https://forums.swift.org/t/swift-snippets/51947

## Dependencies

https://github.com/apple/swift-package-manager/pull/3694

## Testing
1. On VSCode

Navigate to the snippet file. Right-click to open the menu, choose `Swift` and then `Run Swift Snippet`

<img width="199" alt="image" src="https://user-images.githubusercontent.com/43724855/193204508-07813ded-dc4a-48d8-926f-a46f35cff214.png">

3. On Terminal
```shell
# checkout to this branch and cd into swift-markdown repo
export SWIFTPM_ENABLE_SNIPPETS=1 
swift package learn
```

```
# swift-markdown

## Products

- Markdown (library)
- markdown-tool (executable)

## Snippets

0. Parsing (2 snippets)
   Examples on how to use Swift Markdown Framework to parse the Markdown String into Swift object

1. Visiting (1 snippet)
   Examples on how to use Swift Markdown Framework to visit the Markdown object

Choose a group by name or number.
To exit, enter 'q'.
>>> 
```

```
# Parsing

Examples on how to use Swift Markdown Framework to parse the Markdown String into Swift object

0. ParseString
   Example on how to parse Markdown from string

1. ParseFile
   Example on how to parse Markdown from file

Choose a number or a name from the list of snippets.
To go back, press ↩.
To exit, enter `q`.
>>> 
```

## Checklist

- [x] Updated documentation if necessary
