### PR TITLE
parse table cell spans in cmark and use the information

### DIFF
--- a/Sources/Markdown/Base/RawMarkup.swift
+++ b/Sources/Markdown/Base/RawMarkup.swift
@@ -49,7 +49,18 @@ enum RawMarkupData: Equatable {
     case tableHead
     case tableBody
     case tableRow
-    case tableCell
+    case tableCell(colspan: UInt, rowspan: UInt)
+}
+
+extension RawMarkupData {
+    func isTableCell() -> Bool {
+        switch self {
+        case .tableCell:
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 /// The header for the `RawMarkup` managed buffer.
@@ -297,12 +308,12 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
     }
 
     static func tableRow(parsedRange: SourceRange?, _ columns: [RawMarkup]) -> RawMarkup {
-        precondition(columns.allSatisfy { $0.header.data == .tableCell })
+        precondition(columns.allSatisfy { $0.header.data.isTableCell() })
         return .create(data: .tableRow, parsedRange: parsedRange, children: columns)
     }
 
     static func tableHead(parsedRange: SourceRange?, columns: [RawMarkup]) -> RawMarkup {
-        precondition(columns.allSatisfy { $0.header.data == .tableCell })
+        precondition(columns.allSatisfy { $0.header.data.isTableCell() })
         return .create(data: .tableHead, parsedRange: parsedRange, children: columns)
     }
 
@@ -311,8 +322,8 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
         return .create(data: .tableBody, parsedRange: parsedRange, children: rows)
     }
 
-    static func tableCell(parsedRange: SourceRange?, _ children: [RawMarkup]) -> RawMarkup {
-        return .create(data: .tableCell, parsedRange: parsedRange, children: children)
+    static func tableCell(parsedRange: SourceRange?, colspan: UInt, rowspan: UInt, _ children: [RawMarkup]) -> RawMarkup {
+        return .create(data: .tableCell(colspan: colspan, rowspan: rowspan), parsedRange: parsedRange, children: children)
     }
 }
 

--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -974,6 +974,16 @@ public struct MarkupFormatter: MarkupWalker {
             }
         }
 
+        /// Calculate the width of the given column and colspan.
+        ///
+        /// This adds up the appropriate column widths based on the given column span, including
+        /// the default span of 1, where it will only return the `finalColumnWidths` value for the
+        /// given `column`.
+        func columnWidth(column: Int, colspan: Int) -> Int {
+            let lastColumn = column + colspan
+            return (column..<lastColumn).map({ finalColumnWidths[$0] }).reduce(0, { $0 + $1 })
+        }
+
         // We now know the width that each printed column will be.
 
         /// Each of the header cells expanded to the right dimensions by
@@ -986,12 +996,7 @@ public struct MarkupFormatter: MarkupWalker {
                     // can be filled with the spanning cell.
                     return ""
                 } else {
-                    // With a colspan, we want to expand the cell width to
-                    // cover multiple columns. This helpfully generalizes
-                    // to `colspan == 1`, where it will only query the
-                    // current column!
-                    let lastColumn = column + Int(colspan)
-                    let minLineLength = (column..<lastColumn).map({ finalColumnWidths[$0] }).reduce(0, { $0 + $1 })
+                    let minLineLength = columnWidth(column: column, colspan: Int(colspan))
                     return headCellTexts[column]
                         .ensuringCount(atLeast: minLineLength, filler: " ")
                 }
@@ -1030,12 +1035,7 @@ public struct MarkupFormatter: MarkupWalker {
                         // can be filled with the spanning cell.
                         return ""
                     } else {
-                        // With a colspan, we want to expand the cell width to
-                        // cover multiple columns. This helpfully generalizes
-                        // to `colspan == 1`, where it will only query the
-                        // current column!
-                        let lastColumn = column + Int(colspan)
-                        let minLineLength = (column..<lastColumn).map({ finalColumnWidths[$0] }).reduce(0, { $0 + $1 })
+                        let minLineLength = columnWidth(column: column, colspan: Int(colspan))
                         return rowCellTexts[column]
                             .ensuringCount(atLeast: minLineLength, filler: " ")
                     }

--- a/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
@@ -258,4 +258,20 @@ struct MarkupTreeDumper: MarkupWalker {
     mutating func visitSymbolLink(_ symbolLink: SymbolLink) {
         dump(symbolLink, customDescription: symbolLink.destination.map { "destination: \($0)" })
     }
+
+    mutating func visitTableCell(_ tableCell: Table.Cell) {
+        var desc = ""
+        if tableCell.colspan != 1 {
+            desc += " colspan: \(tableCell.colspan)"
+        }
+        if tableCell.rowspan != 1 {
+            desc += " rowspan: \(tableCell.rowspan)"
+        }
+        desc = desc.trimmingCharacters(in: .whitespaces)
+        if !desc.isEmpty {
+            dump(tableCell, customDescription: desc)
+        } else {
+            dump(tableCell)
+        }
+    }
 }

--- a/Tests/MarkdownTests/Block Nodes/TableTests.swift
+++ b/Tests/MarkdownTests/Block Nodes/TableTests.swift
@@ -205,4 +205,40 @@ class TableTests: XCTestCase {
         """
         XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
     }
+
+    func testParseCellSpans() {
+        let source = """
+        | one | two | three |
+        | --- | --- | ----- |
+        | big      || small |
+        | ^        || small |
+        """
+
+        let document = Document(parsing: source)
+
+        let expectedDump = """
+        Document @1:1-4:22
+        └─ Table @1:1-4:22 alignments: |-|-|-|
+           ├─ Head @1:1-1:22
+           │  ├─ Cell @1:2-1:7
+           │  │  └─ Text @1:3-1:6 "one"
+           │  ├─ Cell @1:8-1:13
+           │  │  └─ Text @1:9-1:12 "two"
+           │  └─ Cell @1:14-1:21
+           │     └─ Text @1:15-1:20 "three"
+           └─ Body @3:1-4:22
+              ├─ Row @3:1-3:22
+              │  ├─ Cell @3:2-3:12 colspan: 2 rowspan: 2
+              │  │  └─ Text @3:3-3:6 "big"
+              │  ├─ Cell @3:13-3:14 colspan: 0
+              │  └─ Cell @3:14-3:21
+              │     └─ Text @3:15-3:20 "small"
+              └─ Row @4:1-4:22
+                 ├─ Cell @4:2-4:12 colspan: 2 rowspan: 0
+                 ├─ Cell @4:13-4:14 colspan: 0
+                 └─ Cell @4:14-4:21
+                    └─ Text @4:15-4:20 "small"
+        """
+        XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
+    }
 }

--- a/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
@@ -1265,9 +1265,9 @@ class MarkupFormatterTableTests: XCTestCase {
               │     └─ Link destination: "https://swift.org"
               │        └─ Text "https://swift.org"
               └─ Row
-                 ├─ Cell
+                 ├─ Cell colspan: 2
                  │  └─ InlineHTML <br/>
-                 ├─ Cell
+                 ├─ Cell colspan: 0
                  └─ Cell
         """
         XCTAssertEqual(expectedDump, document.debugDescription())
@@ -1277,7 +1277,58 @@ class MarkupFormatterTableTests: XCTestCase {
         |*A*                       |**B**                 |~C~                |
         |:-------------------------|:--------------------:|------------------:|
         |[Apple](https://apple.com)|![image](image.png "")|<https://swift.org>|
-        |<br/>                     |                      |                   |
+        |<br/>                                           ||                   |
+        """
+
+        XCTAssertEqual(expected, formatted)
+        print(formatted)
+
+        let reparsed = Document(parsing: formatted)
+        print(reparsed.debugDescription())
+        XCTAssertTrue(document.hasSameStructure(as: reparsed))
+    }
+
+    func testRoundTripRowspan() {
+        let source = """
+        | one | two | three |
+        | --- | --- | ----- |
+        | big      || small |
+        | ^        || small |
+        """
+
+        let document = Document(parsing: source)
+
+        let expectedDump = """
+        Document
+        └─ Table alignments: |-|-|-|
+           ├─ Head
+           │  ├─ Cell
+           │  │  └─ Text "one"
+           │  ├─ Cell
+           │  │  └─ Text "two"
+           │  └─ Cell
+           │     └─ Text "three"
+           └─ Body
+              ├─ Row
+              │  ├─ Cell colspan: 2 rowspan: 2
+              │  │  └─ Text "big"
+              │  ├─ Cell colspan: 0
+              │  └─ Cell
+              │     └─ Text "small"
+              └─ Row
+                 ├─ Cell colspan: 2 rowspan: 0
+                 ├─ Cell colspan: 0
+                 └─ Cell
+                    └─ Text "small"
+        """
+        XCTAssertEqual(expectedDump, document.debugDescription())
+
+        let formatted = document.format()
+        let expected = """
+        |one|two|three|
+        |---|---|-----|
+        |big   ||small|
+        |^     ||small|
         """
 
         XCTAssertEqual(expected, formatted)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://98017807

## Summary

This PR adds support for [swift-cmark's new table row- and column-spanning syntax](https://github.com/apple/swift-cmark/pull/46) and enables it by default. (A syntax overview is written up in the linked PR's description.) The spanning values are exposed as properties on the `Table.Cell` struct, with the following semantics:

- A value of 1 is the default, indicating that the cell is not spanning over other cells in that dimension.
- A value of 0 indicates that the cell is being spanned over by another cell in that dimension, and thus should be omitted when rendering HTML.
- A value greater than 1 indicates that the cell is spanning over that number of rows or columns.

Support has been added in Swift-Markdown's Markdown reformatter and its debug tree representation to properly process the new information.

## Dependencies

https://github.com/apple/swift-cmark/pull/46 (already merged)

## Testing

Use the following sample Markdown table, showcasing the new syntax:

```markdown
| one | two | three |
| --- | --- | ----- |
| big      || small |
| ^        || small |
```

Steps:
1. `swift run markdown-tool dump-tree test.md`
2. Compare the output against the following dump:

```
Document
└─ Table alignments: |-|-|-|
   ├─ Head
   │  ├─ Cell
   │  │  └─ Text "one"
   │  ├─ Cell
   │  │  └─ Text "two"
   │  └─ Cell
   │     └─ Text "three"
   └─ Body
      ├─ Row
      │  ├─ Cell colspan: 2 rowspan: 2
      │  │  └─ Text "big"
      │  ├─ Cell colspan: 0
      │  └─ Cell
      │     └─ Text "small"
      └─ Row
         ├─ Cell colspan: 2 rowspan: 0
         ├─ Cell colspan: 0
         └─ Cell
            └─ Text "small"
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
