### PR TITLE
Fix Directive argument name and value ranges on non-first line

### DIFF
--- a/Sources/Markdown/Base/DirectiveArgument.swift
+++ b/Sources/Markdown/Base/DirectiveArgument.swift
@@ -201,8 +201,8 @@ public struct DirectiveArgumentText: Equatable {
             var line = TrimmedLine(untrimmedText[...],
                                    source: range?.lowerBound.source,
                                    lineNumber: range?.lowerBound.line,
-                                   parseIndex: parseIndex,
-                                   startParseIndex: untrimmedText.index(parseIndex, offsetBy: 1 - (range?.lowerBound.column ?? 1)))
+                                   parseIndex: parseIndex
+            )
             line.lexWhitespace()
             while !line.isEmptyOrAllWhitespace {
                 let name: TrimmedLine.Lex?

--- a/Sources/Markdown/Base/DirectiveArgument.swift
+++ b/Sources/Markdown/Base/DirectiveArgument.swift
@@ -76,16 +76,6 @@ public struct DirectiveArgumentText: Equatable {
             self.range = range
         }
 
-        /// Returns a Boolean value indicating whether two line segments are equal.
-        /// - Parameter lhs: a line segment to compare
-        /// - Parameter rhs: another line segment to compare
-        /// - Returns: `true` if the two segments are equal.
-        public static func ==(lhs: LineSegment, rhs: LineSegment) -> Bool {
-            return lhs.untrimmedText == rhs.untrimmedText &&
-                lhs.parseIndex == rhs.parseIndex &&
-                lhs.range == rhs.range
-        }
-
         /// Parse a quoted literal.
         ///
         /// ```

--- a/Sources/Markdown/Base/DirectiveArgument.swift
+++ b/Sources/Markdown/Base/DirectiveArgument.swift
@@ -43,11 +43,14 @@ public struct DirectiveArgumentText: Equatable {
 
     /// A segment of a line of argument text.
     public struct LineSegment: Equatable {
-        /// The segment's untrimmed text from which arguments can be parsed.
+        /// The original untrimmed text of the line, from which arguments can be parsed.
         public var untrimmedText: String
 
-        /// The index in ``untrimmedText`` where the line started.
-        public var lineStartIndex: String.Index
+        @available(*, deprecated, renamed: "untrimmedText.startIndex")
+        public var lineStartIndex: String.Index {
+            get { untrimmedText.startIndex }
+            set { }
+        }
 
         /// The index from which parsing should start.
         public var parseIndex: String.Index
@@ -64,13 +67,11 @@ public struct DirectiveArgumentText: Equatable {
         /// Create an argument line segment.
         /// - Parameters:
         ///   - untrimmedText: the segment's untrimmed text from which arguments can be parsed.
-        ///   - lineStartIndex: the index in ``text`` where the line started.
-        ///   - parseIndex: index from which parsing should start.
+        ///   - parseIndex: The index from which parsing should start.
         ///   - range: The range from which a segment was extracted from a line
         ///     of source, or `nil` if the argument text was provided by other means.
-        init(untrimmedText: String, lineStartIndex: String.Index, parseIndex: String.Index? = nil, range: SourceRange? = nil) {
+        init(untrimmedText: String, parseIndex: String.Index? = nil, range: SourceRange? = nil) {
             self.untrimmedText = untrimmedText
-            self.lineStartIndex = lineStartIndex
             self.parseIndex = parseIndex ?? untrimmedText.startIndex
             self.range = range
         }
@@ -81,7 +82,6 @@ public struct DirectiveArgumentText: Equatable {
         /// - Returns: `true` if the two segments are equal.
         public static func ==(lhs: LineSegment, rhs: LineSegment) -> Bool {
             return lhs.untrimmedText == rhs.untrimmedText &&
-                lhs.lineStartIndex == rhs.lineStartIndex &&
                 lhs.parseIndex == rhs.parseIndex &&
                 lhs.range == rhs.range
         }
@@ -284,7 +284,7 @@ public struct DirectiveArgumentText: Equatable {
     /// from a string.
     public init<S: StringProtocol>(_ string: S) {
         let text = String(string)
-        self.segments = [LineSegment(untrimmedText: text, lineStartIndex: text.startIndex, range: nil)]
+        self.segments = [LineSegment(untrimmedText: text, range: nil)]
     }
 
     /// Create a body of argument text from a sequence of ``LineSegment`` elements.

--- a/Sources/Markdown/Base/DirectiveArgument.swift
+++ b/Sources/Markdown/Base/DirectiveArgument.swift
@@ -201,7 +201,8 @@ public struct DirectiveArgumentText: Equatable {
             var line = TrimmedLine(untrimmedText[...],
                                    source: range?.lowerBound.source,
                                    lineNumber: range?.lowerBound.line,
-                                   parseIndex: parseIndex)
+                                   parseIndex: parseIndex,
+                                   startParseIndex: untrimmedText.index(parseIndex, offsetBy: 1 - (range?.lowerBound.column ?? 1)))
             line.lexWhitespace()
             while !line.isEmptyOrAllWhitespace {
                 let name: TrimmedLine.Lex?

--- a/Sources/Markdown/Base/DirectiveArgument.swift
+++ b/Sources/Markdown/Base/DirectiveArgument.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/BlockDirective.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/BlockDirective.swift
@@ -95,7 +95,6 @@ public extension BlockDirective {
                                                    omittingEmptySubsequences: false).map { lineText -> DirectiveArgumentText.LineSegment in
                                                     let untrimmedText = String(lineText)
                                                     return DirectiveArgumentText.LineSegment(untrimmedText: untrimmedText,
-                                                                                             lineStartIndex: untrimmedText.startIndex,
                                                                                              range: nil)
                                                    } ?? []
         try! self.init(.blockDirective(name: name,

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/BlockDirective.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/BlockDirective.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -282,9 +282,6 @@ struct TrimmedLine {
     /// The original untrimmed text of the line.
     let untrimmedText: Substring
 
-    /// The starting parse index.
-    let startParseIndex: Substring.Index
-
     /// The current index a parser is looking at on a line.
     var parseIndex: Substring.Index
 
@@ -303,13 +300,16 @@ struct TrimmedLine {
         }
     }
 
-    /// - parameter untrimmedText: ``untrimmedText``
-    init(_ untrimmedText: Substring, source: URL?, lineNumber: Int?, parseIndex: Substring.Index? = nil, startParseIndex: Substring.Index? = nil) {
+    /// - Parameters:
+    ///   - untrimmedText: The original untrimmed text of the line.
+    ///   - source: The source file or resource from which the line came, or `nil` if no such file or resource can be identified.
+    ///   - lineNumber: The line number of this line in the source if known, starting with `0`.
+    ///   - parseIndex: The current index a parser is looking at on a line, or `nil` if a parser is looking at the start of the untrimmed text.
+    init(_ untrimmedText: Substring, source: URL?, lineNumber: Int?, parseIndex: Substring.Index? = nil) {
         self.untrimmedText = untrimmedText
         self.source = source
         self.parseIndex = parseIndex ?? untrimmedText.startIndex
         self.lineNumber = lineNumber
-        self.startParseIndex = startParseIndex ?? self.parseIndex
     }
 
     /// Return the UTF-8 source location of the parse index if the line
@@ -318,10 +318,7 @@ struct TrimmedLine {
         guard let lineNumber = lineNumber else {
             return nil
         }
-        let startIndex = lineNumber == 1
-            ? untrimmedText.startIndex
-            : startParseIndex
-        let alreadyParsedPrefix = untrimmedText[startIndex..<parseIndex]
+        let alreadyParsedPrefix = untrimmedText[..<parseIndex]
         return .init(line: lineNumber, column: alreadyParsedPrefix.utf8.count + 1, source: source)
     }
 
@@ -718,14 +715,27 @@ private enum ParseContainer: CustomStringConvertible {
             let children = children.flatMap {
                 $0.convertToRawMarkup(ranges: &ranges, parent: self, options: options)
             }
-            return [.blockDirective(name: String(pendingBlockDirective.name),
-                                    nameLocation: pendingBlockDirective.atLocation,
-                                    argumentText: DirectiveArgumentText(segments: pendingBlockDirective.argumentsText.map {
-                                        let untrimmedText = String($0.text.base[$0.text.base.startIndex..<$0.text.endIndex])
-                                        return DirectiveArgumentText.LineSegment(untrimmedText: untrimmedText, lineStartIndex: untrimmedText.startIndex, parseIndex: $0.text.startIndex, range: $0.range)
-                                    }),
-                                    parsedRange: pendingBlockDirective.atLocation..<pendingBlockDirective.endLocation,
-                                    children)]
+            return [.blockDirective(
+                name: String(pendingBlockDirective.name),
+                nameLocation: pendingBlockDirective.atLocation,
+                argumentText: DirectiveArgumentText(segments: pendingBlockDirective.argumentsText.map {
+                    let base = $0.text.base
+                    let lineStartIndex: String.Index
+                    if let argumentRange = $0.range {
+                        // If the argument has a known source range, offset the column (number of UTF8 bytes) to find the start of the line.
+                        lineStartIndex = base.utf8.index($0.text.startIndex, offsetBy: 1 - argumentRange.lowerBound.column)
+                    } else if let newLineIndex = base[..<$0.text.startIndex].lastIndex(where: \.isNewline) {
+                        // Iterate backwards from the argument start index to find the the start of the line.
+                        lineStartIndex = base.utf8.index(after: newLineIndex)
+                    } else {
+                        lineStartIndex = base.startIndex
+                    }
+                    let parseIndex = base.utf8.index($0.text.startIndex, offsetBy: -base.utf8.distance(from: base.startIndex, to: lineStartIndex))
+                    let untrimmedLine = String(base[lineStartIndex..<$0.text.endIndex])
+                    return DirectiveArgumentText.LineSegment(untrimmedText: untrimmedLine, lineStartIndex: untrimmedLine.startIndex, parseIndex: parseIndex, range: $0.range)
+                }),
+                parsedRange: pendingBlockDirective.atLocation..<pendingBlockDirective.endLocation,
+                children)]
         case let .doxygenCommand(pendingDoxygenCommand, lines):
             let range = pendingDoxygenCommand.atLocation..<pendingDoxygenCommand.endLocation
             ranges.add(range)

--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -732,7 +732,7 @@ private enum ParseContainer: CustomStringConvertible {
                     }
                     let parseIndex = base.utf8.index($0.text.startIndex, offsetBy: -base.utf8.distance(from: base.startIndex, to: lineStartIndex))
                     let untrimmedLine = String(base[lineStartIndex..<$0.text.endIndex])
-                    return DirectiveArgumentText.LineSegment(untrimmedText: untrimmedLine, lineStartIndex: untrimmedLine.startIndex, parseIndex: parseIndex, range: $0.range)
+                    return DirectiveArgumentText.LineSegment(untrimmedText: untrimmedLine, parseIndex: parseIndex, range: $0.range)
                 }),
                 parsedRange: pendingBlockDirective.atLocation..<pendingBlockDirective.endLocation,
                 children)]

--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -318,7 +318,7 @@ struct TrimmedLine {
         guard let lineNumber = lineNumber else {
             return nil
         }
-        let startIndex = (self.lineNumber ?? 1) == 1
+        let startIndex = lineNumber == 1
             ? untrimmedText.startIndex
             : startParseIndex
         let alreadyParsedPrefix = untrimmedText[startIndex..<parseIndex]

--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -304,12 +304,12 @@ struct TrimmedLine {
     }
 
     /// - parameter untrimmedText: ``untrimmedText``
-    init(_ untrimmedText: Substring, source: URL?, lineNumber: Int?, parseIndex: Substring.Index? = nil) {
+    init(_ untrimmedText: Substring, source: URL?, lineNumber: Int?, parseIndex: Substring.Index? = nil, startParseIndex: Substring.Index? = nil) {
         self.untrimmedText = untrimmedText
         self.source = source
         self.parseIndex = parseIndex ?? untrimmedText.startIndex
         self.lineNumber = lineNumber
-        self.startParseIndex = self.parseIndex
+        self.startParseIndex = startParseIndex ?? self.parseIndex
     }
 
     /// Return the UTF-8 source location of the parse index if the line

--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -715,27 +715,30 @@ private enum ParseContainer: CustomStringConvertible {
             let children = children.flatMap {
                 $0.convertToRawMarkup(ranges: &ranges, parent: self, options: options)
             }
-            return [.blockDirective(
-                name: String(pendingBlockDirective.name),
-                nameLocation: pendingBlockDirective.atLocation,
-                argumentText: DirectiveArgumentText(segments: pendingBlockDirective.argumentsText.map {
-                    let base = $0.text.base
-                    let lineStartIndex: String.Index
-                    if let argumentRange = $0.range {
-                        // If the argument has a known source range, offset the column (number of UTF8 bytes) to find the start of the line.
-                        lineStartIndex = base.utf8.index($0.text.startIndex, offsetBy: 1 - argumentRange.lowerBound.column)
-                    } else if let newLineIndex = base[..<$0.text.startIndex].lastIndex(where: \.isNewline) {
-                        // Iterate backwards from the argument start index to find the the start of the line.
-                        lineStartIndex = base.utf8.index(after: newLineIndex)
-                    } else {
-                        lineStartIndex = base.startIndex
-                    }
-                    let parseIndex = base.utf8.index($0.text.startIndex, offsetBy: -base.utf8.distance(from: base.startIndex, to: lineStartIndex))
-                    let untrimmedLine = String(base[lineStartIndex..<$0.text.endIndex])
-                    return DirectiveArgumentText.LineSegment(untrimmedText: untrimmedLine, parseIndex: parseIndex, range: $0.range)
-                }),
-                parsedRange: pendingBlockDirective.atLocation..<pendingBlockDirective.endLocation,
-                children)]
+            return [
+                .blockDirective(
+                    name: String(pendingBlockDirective.name),
+                    nameLocation: pendingBlockDirective.atLocation,
+                    argumentText: DirectiveArgumentText(segments: pendingBlockDirective.argumentsText.map {
+                        let base = $0.text.base
+                        let lineStartIndex: String.Index
+                        if let argumentRange = $0.range {
+                            // If the argument has a known source range, offset the column (number of UTF8 bytes) to find the start of the line.
+                            lineStartIndex = base.utf8.index($0.text.startIndex, offsetBy: 1 - argumentRange.lowerBound.column)
+                        } else if let newLineIndex = base[..<$0.text.startIndex].lastIndex(where: \.isNewline) {
+                            // Iterate backwards from the argument start index to find the the start of the line.
+                            lineStartIndex = base.utf8.index(after: newLineIndex)
+                        } else {
+                            lineStartIndex = base.startIndex
+                        }
+                        let parseIndex = base.utf8.index($0.text.startIndex, offsetBy: -base.utf8.distance(from: base.startIndex, to: lineStartIndex))
+                        let untrimmedLine = String(base[lineStartIndex ..< $0.text.endIndex])
+                        return DirectiveArgumentText.LineSegment(untrimmedText: untrimmedLine, parseIndex: parseIndex, range: $0.range)
+                    }),
+                    parsedRange: pendingBlockDirective.atLocation ..< pendingBlockDirective.endLocation,
+                    children
+                ),
+            ]
         case let .doxygenCommand(pendingDoxygenCommand, lines):
             let range = pendingDoxygenCommand.atLocation..<pendingDoxygenCommand.endLocation
             ranges.add(range)

--- a/Tests/MarkdownTests/Parsing/BlockDirectiveParserTests.swift
+++ b/Tests/MarkdownTests/Parsing/BlockDirectiveParserTests.swift
@@ -1042,6 +1042,30 @@ class BlockDirectiveArgumentParserTests: XCTestCase {
               └─ Text "Line c This is a single-line comment"
         """
         XCTAssertEqual(expected, documentation.debugDescription())
+    
+    func testDirectiveArgumentOnNonfirstLineParsing() throws {
+        let source = """
+
+        @Options(scope: page)
+        """
+
+        let line = 2
+        let document = Document(parsing: source, options: .parseBlockDirectives)
+        let directive = try XCTUnwrap(document.child(at: 0) as? BlockDirective)
+        let arguments = directive.argumentText.parseNameValueArguments()
+        let scopeArg = try XCTUnwrap(arguments["scope"])
+
+        XCTAssertEqual("scope", scopeArg.name)
+        XCTAssertEqual(
+            scopeArg.nameRange,
+            SourceLocation(line: line, column: 10, source: nil) ..< SourceLocation(line: line, column: 15, source: nil)
+        )
+
+        XCTAssertEqual("page", scopeArg.value)
+        XCTAssertEqual(
+            scopeArg.valueRange,
+            SourceLocation(line: line, column: 17, source: nil) ..< SourceLocation(line: line, column: 21, source: nil)
+        )
     }
 
     // FIXME: swift-testing macro for specifying the relationship between a bug and a test


### PR DESCRIPTION
Bug/issue #, if applicable: 

Close #71 

## Summary

- Remove unnecessary optional check
- Fix and add test case for single line block parse

## Dependencies

None

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
