### PR TITLE
Fix link missing range issue

### DIFF
--- a/Sources/Markdown/Inline Nodes/Inline Containers/Link.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/Link.swift
@@ -58,7 +58,7 @@ public extension Link {
             if let d = newValue, d.isEmpty {
                 _data = _data.replacingSelf(.link(destination: nil, parsedRange: nil, _data.raw.markup.copyChildren()))
             } else {
-                _data = _data.replacingSelf(.link(destination: newValue, parsedRange: nil, _data.raw.markup.copyChildren()))
+                _data = _data.replacingSelf(.link(destination: newValue, parsedRange: _data.range, _data.raw.markup.copyChildren()))
             }
         }
     }


### PR DESCRIPTION
Bug/issue #, if applicable: 

With https://github.com/apple/swift-docc/pull/376

Close https://github.com/apple/swift-docc/issues/271

## Summary

When updating destination of link, we preserve the old `parsedRange` instead of setting to nil.

The `parsedRange` is indeed out of date and we should not rely on it. But sometimes we need the original `parsedRange` to do some logic.

See discussion on https://github.com/apple/swift-docc/issues/271#issuecomment-1272279547

## Dependencies

None

## Testing


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
