### PR TITLE
Pin version range of plugin dependency

### DIFF
--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -58,7 +58,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // SwiftPM command plugins are only supported by Swift version 5.6 and later.
     #if swift(>=5.6)
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-docc-plugin", .branch("main")),
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0"),
     ]
     #endif
 } else {


### PR DESCRIPTION
Start with the 1.1.0 version of the swift-docc-plugin dependency instead of the main branch, which may be unstable.