### PR TITLE
Add line break tests for hard breaks.

### DIFF
--- a/Tests/MarkdownTests/Inline Nodes/LineBreakTests.swift
+++ b/Tests/MarkdownTests/Inline Nodes/LineBreakTests.swift
@@ -25,4 +25,39 @@ final class LineBreakTests: XCTestCase {
         let paragraph = document.child(at: 0) as! Paragraph
         XCTAssertTrue(Array(paragraph.children)[1] is LineBreak)
     }
+
+    /// Test that hard line breaks work with spaces (two or more).
+    func testSpaceHardLineBreak() {
+        let source = """
+                     Paragraph.\("  ")
+                     Still the same paragraph.
+                     """
+        let document = Document(parsing: source)
+        let paragraph = document.child(at: 0) as! Paragraph
+        XCTAssertTrue(Array(paragraph.children)[1] is LineBreak)
+    }
+
+    /// Test that hard line breaks work with a slash.
+    func testSlashHardLineBreak() {
+        let source = """
+                     Paragraph.\\
+                     Still the same paragraph.
+                     """
+        let document = Document(parsing: source)
+        let paragraph = document.child(at: 0) as! Paragraph
+        XCTAssertTrue(Array(paragraph.children)[1] is LineBreak)
+    }
+
+    /// Sanity test that a multiline text without hard breaks doesn't return line breaks.
+    func testLineBreakWithout() {
+        let source = """
+                     Paragraph.
+                     Same line text.
+                     """
+        let document = Document(parsing: source)
+        
+        let paragraph = document.child(at: 0) as! Paragraph
+        XCTAssertFalse(Array(paragraph.children)[1] is LineBreak)
+        XCTAssertEqual(Array(paragraph.children)[1].withoutSoftBreaks?.childCount, nil)
+    }
 }

--- a/Tests/MarkdownTests/Inline Nodes/LineBreakTests.swift
+++ b/Tests/MarkdownTests/Inline Nodes/LineBreakTests.swift
@@ -39,10 +39,10 @@ final class LineBreakTests: XCTestCase {
 
     /// Test that hard line breaks work with a slash.
     func testSlashHardLineBreak() {
-        let source = """
-                     Paragraph.\\
+        let source = #"""
+                     Paragraph.\
                      Still the same paragraph.
-                     """
+                     """#
         let document = Document(parsing: source)
         let paragraph = document.child(at: 0) as! Paragraph
         XCTAssertTrue(Array(paragraph.children)[1] is LineBreak)


### PR DESCRIPTION
Bug/issue #, if applicable: apple/swift-docc#477 

## Summary

Was looking into apple/swift-docc#477 and by adding tests for the hard breaks, noticed that it seems to work as expected. As long as the user escapes the needed trailing whitespace and slash. Seems to me that apple/swift-docc#477 is not a bug in this repo.

## Dependencies

None

## Testing

The content of the PR are tests.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
