### PR TITLE
Fix typo loacation to location.

### DIFF
--- a/Tests/MarkdownTests/Infrastructure/SourceLocationTests.swift
+++ b/Tests/MarkdownTests/Infrastructure/SourceLocationTests.swift
@@ -11,7 +11,7 @@
 @testable import Markdown
 import XCTest
 
-class SourceLoacationTests: XCTestCase {
+class SourceLocationTests: XCTestCase {
     func testNonAsciiCharacterColumn() throws {
         func assertColumnNumberAssumesUTF8Encoding(text: String) throws {
             let document = Document(parsing: text)


### PR DESCRIPTION
## Summary

Noticed that there was a typo on a file name, and the test class it contained. This PR fixes that typo.

## Dependencies

None

## Testing

Check that the typo is fixed correctly.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
