### PR TITLE
Allow separate strong emphasis marker

### DIFF
--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -239,6 +239,7 @@ public struct MarkupFormatter: MarkupWalker {
         var thematicBreakCharacter: ThematicBreakCharacter
         var thematicBreakLength: UInt
         var emphasisMarker: EmphasisMarker
+        var strongEmphasisMarker: EmphasisMarker
         var condenseAutolinks: Bool
         var preferredHeadingStyle: PreferredHeadingStyle
         var preferredLineLimit: PreferredLineLimit?
@@ -254,7 +255,8 @@ public struct MarkupFormatter: MarkupWalker {
             - defaultCodeBlockLanguage: The default language string to use when code blocks don't have a language and will be printed as fenced code blocks.
             - thematicBreakCharacter: The character to use for thematic breaks.
             - thematicBreakLength: The length of printed thematic breaks.
-            - emphasisMarker: The character to use for emphasis and strong emphasis markers.
+            - emphasisMarker: The character to use for emphasis markers.
+            - strongEmphasisMarker: The character to use for strong emphasis markers.
             - condenseAutolinks: Print links whose link text and destination match as autolinks, e.g. `<https://swift.org>`.
             - preferredHeadingStyle: The preferred heading style.
             - lineLimit: The preferred maximum line length and method for splitting ``Text`` elements in an attempt to maintain that line length.
@@ -267,6 +269,7 @@ public struct MarkupFormatter: MarkupWalker {
                     thematicBreakCharacter: ThematicBreakCharacter = .dash,
                     thematicBreakLength: UInt = 5,
                     emphasisMarker: EmphasisMarker = .star,
+                    strongEmphasisMarker: EmphasisMarker = .star,
                     condenseAutolinks: Bool = true,
                     preferredHeadingStyle: PreferredHeadingStyle = .atx,
                     preferredLineLimit: PreferredLineLimit? = nil,
@@ -277,6 +280,7 @@ public struct MarkupFormatter: MarkupWalker {
             self.defaultCodeBlockLanguage = defaultCodeBlockLanguage
             self.thematicBreakCharacter = thematicBreakCharacter
             self.emphasisMarker = emphasisMarker
+            self.strongEmphasisMarker = strongEmphasisMarker
             self.condenseAutolinks = condenseAutolinks
             self.preferredHeadingStyle = preferredHeadingStyle
             self.preferredLineLimit = preferredLineLimit
@@ -841,9 +845,9 @@ public struct MarkupFormatter: MarkupWalker {
     }
 
     public mutating func visitStrong(_ strong: Strong) {
-        print(String(repeating: formattingOptions.emphasisMarker.rawValue, count: 2), for: strong)
+        print(String(repeating: formattingOptions.strongEmphasisMarker.rawValue, count: 2), for: strong)
         descendInto(strong)
-        print(String(repeating: formattingOptions.emphasisMarker.rawValue, count: 2), for: strong)
+        print(String(repeating: formattingOptions.strongEmphasisMarker.rawValue, count: 2), for: strong)
     }
 
     public mutating func visitText(_ text: Text) {

--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -269,7 +269,7 @@ public struct MarkupFormatter: MarkupWalker {
                     thematicBreakCharacter: ThematicBreakCharacter = .dash,
                     thematicBreakLength: UInt = 5,
                     emphasisMarker: EmphasisMarker = .star,
-                    strongEmphasisMarker: EmphasisMarker = .star,
+                    strongEmphasisMarker: EmphasisMarker? = nil,
                     condenseAutolinks: Bool = true,
                     preferredHeadingStyle: PreferredHeadingStyle = .atx,
                     preferredLineLimit: PreferredLineLimit? = nil,
@@ -280,7 +280,7 @@ public struct MarkupFormatter: MarkupWalker {
             self.defaultCodeBlockLanguage = defaultCodeBlockLanguage
             self.thematicBreakCharacter = thematicBreakCharacter
             self.emphasisMarker = emphasisMarker
-            self.strongEmphasisMarker = strongEmphasisMarker
+            self.strongEmphasisMarker = strongEmphasisMarker ?? emphasisMarker
             self.condenseAutolinks = condenseAutolinks
             self.preferredHeadingStyle = preferredHeadingStyle
             self.preferredLineLimit = preferredLineLimit

--- a/Sources/markdown-tool/Commands/FormatCommand.swift
+++ b/Sources/markdown-tool/Commands/FormatCommand.swift
@@ -97,7 +97,7 @@ extension MarkdownCommand {
         var emphasisMarker: String = "*"
 
         @Option(help: "Strong emphasis marker; choices: \(MarkupFormatter.Options.EmphasisMarker.allCases.map { $0.rawValue }.joined(separator: ", "))")
-        var strongEmphasisMarker: String = "*"
+        var strongEmphasisMarker: String?
 
         @Flag(inversion: .prefixedNo, exclusivity: .chooseLast, help: "Condense links whose text matches their destination to 'autolinks' e.g. <https://swift.org>")
         var condenseAutolinks: Bool = true
@@ -211,7 +211,7 @@ extension MarkdownCommand {
                 throw ArgumentParser.ValidationError("The value '\(self.emphasisMarker)' is invalid for '--emphasis-marker'")
             }
 
-            guard let strongEmphasisMarker = MarkupFormatter.Options.EmphasisMarker(argument: strongEmphasisMarker) else {
+            guard let strongEmphasisMarker = MarkupFormatter.Options.EmphasisMarker(argument: strongEmphasisMarker ?? self.emphasisMarker) else {
                 throw ArgumentParser.ValidationError("The value '\(self.strongEmphasisMarker)' is invalid for '--strong-emphasis-marker'")
             }
 

--- a/Sources/markdown-tool/Commands/FormatCommand.swift
+++ b/Sources/markdown-tool/Commands/FormatCommand.swift
@@ -96,6 +96,9 @@ extension MarkdownCommand {
         @Option(help: "Emphasis marker; choices: \(MarkupFormatter.Options.EmphasisMarker.allCases.map { $0.rawValue }.joined(separator: ", "))")
         var emphasisMarker: String = "*"
 
+        @Option(help: "Strong emphasis marker; choices: \(MarkupFormatter.Options.EmphasisMarker.allCases.map { $0.rawValue }.joined(separator: ", "))")
+        var strongEmphasisMarker: String = "*"
+
         @Flag(inversion: .prefixedNo, exclusivity: .chooseLast, help: "Condense links whose text matches their destination to 'autolinks' e.g. <https://swift.org>")
         var condenseAutolinks: Bool = true
 
@@ -208,6 +211,10 @@ extension MarkdownCommand {
                 throw ArgumentParser.ValidationError("The value '\(self.emphasisMarker)' is invalid for '--emphasis-marker'")
             }
 
+            guard let strongEmphasisMarker = MarkupFormatter.Options.EmphasisMarker(argument: strongEmphasisMarker) else {
+                throw ArgumentParser.ValidationError("The value '\(self.strongEmphasisMarker)' is invalid for '--strong-emphasis-marker'")
+            }
+
             guard let unorderedListMarker = MarkupFormatter.Options.UnorderedListMarker(argument: unorderedListMarker) else {
                 throw ArgumentParser.ValidationError("The value '\(self.emphasisMarker)' is invalid for '--unordered-list-marker'")
             }
@@ -231,6 +238,7 @@ extension MarkdownCommand {
                                                   thematicBreakCharacter: thematicBreakCharacter,
                                                   thematicBreakLength: thematicBreakLength,
                                                   emphasisMarker: emphasisMarker,
+                                                  strongEmphasisMarker: strongEmphasisMarker,
                                                   condenseAutolinks: condenseAutolinks,
                                                   preferredHeadingStyle: preferredHeadingStyle,
                                                   preferredLineLimit: preferredLineLimit,

--- a/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
@@ -433,6 +433,23 @@ class MarkupFormatterOptionsTests: XCTestCase {
 
             do {
                 let document = Document(parsing: underline)
+                let printed = document.format(options: .init(emphasisMarker: .star))
+                XCTAssertEqual(star, printed)
+            }
+
+            do {
+                let document = Document(parsing: star)
+                let printed = document.format(options: .init(emphasisMarker: .underline))
+                XCTAssertEqual(underline, printed)
+            }
+        }
+
+        do {
+            let underline = "__strong__"
+            let star = "**strong**"
+
+            do {
+                let document = Document(parsing: underline)
                 let printed = document.format(options: .init(strongEmphasisMarker: .star))
                 XCTAssertEqual(star, printed)
             }
@@ -442,7 +459,23 @@ class MarkupFormatterOptionsTests: XCTestCase {
                 let printed = document.format(options: .init(strongEmphasisMarker: .underline))
                 XCTAssertEqual(underline, printed)
             }
+        }
 
+        do {
+            let underline = "__strong__"
+            let star = "**strong**"
+
+            do {
+                let document = Document(parsing: underline)
+                let printed = document.format(options: .init(emphasisMarker: .underline, strongEmphasisMarker: .star))
+                XCTAssertEqual(star, printed)
+            }
+
+            do {
+                let document = Document(parsing: star)
+                let printed = document.format(options: .init(emphasisMarker: .star, strongEmphasisMarker: .underline))
+                XCTAssertEqual(underline, printed)
+            }
         }
     }
 

--- a/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
@@ -433,13 +433,13 @@ class MarkupFormatterOptionsTests: XCTestCase {
 
             do {
                 let document = Document(parsing: underline)
-                let printed = document.format(options: .init(emphasisMarker: .star))
+                let printed = document.format(options: .init(strongEmphasisMarker: .star))
                 XCTAssertEqual(star, printed)
             }
 
             do {
                 let document = Document(parsing: star)
-                let printed = document.format(options: .init(emphasisMarker: .underline))
+                let printed = document.format(options: .init(strongEmphasisMarker: .underline))
                 XCTAssertEqual(underline, printed)
             }
 


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

As it stands, the selection of an `emphasisMarker` in `MarkupFormatter.Options` determines the marker used for both _emphasis_ and **strong emphasis**. However, the Markdown spec allows one to, and I prefer to, use different markers for emphasis as compared to strong emphasis. For example: `_emphasis_` and `**strong emphasis**`.

This PR adds an `Optional` parameter to `MarkupFormatter.Options` that allows one to specify the marker used for strong emphasis. If omitted, it takes on the value of the marker used for normal emphasis.

## Dependencies

None

## Testing

I've updated the bundled `markdown-tool` as well, so you can simply run:
```
echo "Here's some **strong emphasis** and some _normal emphasis_" | swift run markdown-tool format --emphasis-marker _ --strong-emphasis-marker \*
```
which will replicate the input as output. But if one runs:
```
echo "Here's some **strong emphasis** and some _normal emphasis_" | swift run markdown-tool format --emphasis-marker _
```
the output is `Here's some __strong emphasis__ and some _normal emphasis_` — i.e., the previous behavior is honored.

Steps:
1. Clone this PR/my repository
2. Run the above commands

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary

The `./bin/test` script already fails for me on `main`, but I haven't introduced any new issues.