### PR TITLE
Fix typo in markdown-tool validation error

### DIFF
--- a/Sources/markdown-tool/Commands/FormatCommand.swift
+++ b/Sources/markdown-tool/Commands/FormatCommand.swift
@@ -209,7 +209,7 @@ extension MarkdownCommand {
             }
 
             guard let unorderedListMarker = MarkupFormatter.Options.UnorderedListMarker(argument: unorderedListMarker) else {
-                throw ArgumentParser.ValidationError("The value '\(self.emphasisMarker)' is invalid for '--unordered-list-marker'")
+                throw ArgumentParser.ValidationError("The value '\(self.unorderedListMarker)' is invalid for '--unordered-list-marker'")
             }
 
             let orderedListNumerals: MarkupFormatter.Options.OrderedListNumerals


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

Fixes a typo in the bundled `markdown-tool` example command.

## Dependencies

None

## Testing

```
echo "" | swift run markdown-tool format --unordered-list-marker 1
```
now errors with the value passed as an option, not the unrelated value of `emphasisMarker`

Steps:
1. Clone this PR/my repository
2. Run the above command

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary

There are no tests for the `markdown-tool`, so I didn't add any. The `./bin/test` script failed for me on main, but I didn't cause any new issues. There is no documentation to update