### PR TITLE
fix check-license to properly check snippets

### DIFF
--- a/Snippets/Parsing/test.md
+++ b/Snippets/Parsing/test.md
@@ -1,3 +1,5 @@
 # Sample document
 
 This is a *sample document*.
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/Markdown/Markdown.docc/Snippets.md
+++ b/Sources/Markdown/Markdown.docc/Snippets.md
@@ -41,3 +41,5 @@ a Markdown document to a consistent, preferred style.
 @Snippet(path: "swift-markdown/Snippets/Formatting/PreferredHeadingStyle")
 @Snippet(path: "swift-markdown/Snippets/Formatting/ThematicBreakCharacter")
 @Snippet(path: "swift-markdown/Snippets/Formatting/UseCodeFence")
+
+<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/bin/check-source
+++ b/bin/check-source
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][78901]-20[12][89012]/YEARS/' -e 's/20[12][89012]/YEARS/'
+    sed -e 's/20[12][7890123]-20[12][890123]/YEARS/' -e 's/20[12][890123]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language… "

--- a/bin/check-source
+++ b/bin/check-source
@@ -49,7 +49,7 @@ for language in swift-or-c bash md-or-tutorial html docker; do
   reader=head
   case "$language" in
       swift-or-c)
-        exceptions=( -name 'Package*.swift')
+        exceptions=( -name 'Package*.swift' -o -path './Snippets/*')
         matching_files=( -name '*.swift' -o -name '*.c' -o -name '*.h' )
         cat > "$tmp" <<"EOF"
 /*

--- a/bin/check-source
+++ b/bin/check-source
@@ -40,7 +40,7 @@ printf "\033[0;32mokay.\033[0m\n"
 printf "=> Checking license headers… "
 tmp=$(mktemp /tmp/.swift-markdown-check-source_XXXXXX)
 
-for language in swift-or-c bash md-or-tutorial html docker; do
+for language in swift-or-c snippet bash md-or-tutorial html docker; do
   declare -a matching_files
   declare -a exceptions
   declare -a reader
@@ -51,6 +51,22 @@ for language in swift-or-c bash md-or-tutorial html docker; do
       swift-or-c)
         exceptions=( -name 'Package*.swift' -o -path './Snippets/*')
         matching_files=( -name '*.swift' -o -name '*.c' -o -name '*.h' )
+        cat > "$tmp" <<"EOF"
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) YEARS Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+EOF
+        ;;
+      snippet)
+        matching_files=( -name '*.swift' -a -path './Snippets/*')
+        exceptions=( -name 'Package*.swift')
+        reader=tail
         cat > "$tmp" <<"EOF"
 /*
  This source file is part of the Swift.org open source project
@@ -150,3 +166,4 @@ done
 printf "\033[0;32mokay.\033[0m\n"
 rm "$tmp"
 
+# vim: filetype=bash shiftwidth=2 softtabstop=2


### PR DESCRIPTION
Bug/issue #, if applicable: None

## Summary

When snippets were introduced to swift-markdown, the `check-source` script wasn't updated to handle the way the license statement was written. This caused the `bin/test` script to start failing. This PR updates the `check-source` script to handle snippet files separately, since they have their license text written at the end of the file, instead of the beginning.

## Dependencies

None

## Testing

Ensure that `bin/test` (specifically `bin/check-source`) succeeds with the snippets in the repo.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
