### PR TITLE
basic support for parsing Doxygen `\param` and `\returns` commands

### DIFF
--- a/Sources/Markdown/Base/Markup.swift
+++ b/Sources/Markdown/Base/Markup.swift
@@ -71,6 +71,8 @@ func makeMarkup(_ data: _MarkupData) -> Markup {
         return SymbolLink(data)
     case .inlineAttributes:
         return InlineAttributes(data)
+    case .doxygenParam:
+        return DoxygenParam(data)
     }
 }
 

--- a/Sources/Markdown/Base/Markup.swift
+++ b/Sources/Markdown/Base/Markup.swift
@@ -72,7 +72,7 @@ func makeMarkup(_ data: _MarkupData) -> Markup {
     case .inlineAttributes:
         return InlineAttributes(data)
     case .doxygenParam:
-        return DoxygenParam(data)
+        return DoxygenParameter(data)
     case .doxygenReturns:
         return DoxygenReturns(data)
     }

--- a/Sources/Markdown/Base/Markup.swift
+++ b/Sources/Markdown/Base/Markup.swift
@@ -73,6 +73,8 @@ func makeMarkup(_ data: _MarkupData) -> Markup {
         return InlineAttributes(data)
     case .doxygenParam:
         return DoxygenParam(data)
+    case .doxygenReturns:
+        return DoxygenReturns(data)
     }
 }
 

--- a/Sources/Markdown/Base/RawMarkup.swift
+++ b/Sources/Markdown/Base/RawMarkup.swift
@@ -53,6 +53,7 @@ enum RawMarkupData: Equatable {
     case tableCell(colspan: UInt, rowspan: UInt)
 
     case doxygenParam(name: String)
+    case doxygenReturns
 }
 
 extension RawMarkupData {
@@ -335,6 +336,10 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
 
     static func doxygenParam(name: String, parsedRange: SourceRange?, _ children: [RawMarkup]) -> RawMarkup {
         return .create(data: .doxygenParam(name: name), parsedRange: parsedRange, children: children)
+    }
+
+    static func doxygenReturns(parsedRange: SourceRange?, _ children: [RawMarkup]) -> RawMarkup {
+        return .create(data: .doxygenReturns, parsedRange: parsedRange, children: children)
     }
 }
 

--- a/Sources/Markdown/Base/RawMarkup.swift
+++ b/Sources/Markdown/Base/RawMarkup.swift
@@ -51,6 +51,8 @@ enum RawMarkupData: Equatable {
     case tableBody
     case tableRow
     case tableCell(colspan: UInt, rowspan: UInt)
+
+    case doxygenParam(name: String)
 }
 
 extension RawMarkupData {
@@ -329,6 +331,10 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
 
     static func tableCell(parsedRange: SourceRange?, colspan: UInt, rowspan: UInt, _ children: [RawMarkup]) -> RawMarkup {
         return .create(data: .tableCell(colspan: colspan, rowspan: rowspan), parsedRange: parsedRange, children: children)
+    }
+
+    static func doxygenParam(name: String, parsedRange: SourceRange?, _ children: [RawMarkup]) -> RawMarkup {
+        return .create(data: .doxygenParam(name: name), parsedRange: parsedRange, children: children)
     }
 }
 

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenParam.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenParam.swift
@@ -1,0 +1,78 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+/// A parsed Doxygen `\param` command.
+///
+/// The Doxygen support in Swift-Markdown parses `\param` commands of the form
+/// `\param name description`, where `description` extends until the next blank line or the next
+/// parsed command. For example, the following input will return two `DoxygenParam` instances:
+///
+/// ```markdown
+/// \param coordinate The coordinate used to center the transformation.
+/// \param matrix The transformation matrix that describes the transformation.
+/// For more information about transformation matrices, refer to the Transformation
+/// documentation.
+/// ```
+public struct DoxygenParam: BlockContainer {
+    public var _data: _MarkupData
+
+    init(_ raw: RawMarkup) throws {
+        guard case .doxygenParam = raw.data else {
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: BlockDirective.self)
+        }
+        let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
+        self.init(_MarkupData(absoluteRaw))
+    }
+
+    init(_ data: _MarkupData) {
+        self._data = data
+    }
+
+    public func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
+        return visitor.visitDoxygenParam(self)
+    }
+}
+
+public extension DoxygenParam {
+    /// Create a new Doxygen parameter definition.
+    ///
+    /// - Parameter name: The name of the parameter being described.
+    /// - Parameter children: Block child elements.
+    init<Children: Sequence>(name: String, children: Children) where Children.Element == BlockMarkup {
+        try! self.init(.doxygenParam(name: name, parsedRange: nil, children.map({ $0.raw.markup })))
+    }
+
+    /// Create a new Doxygen parameter definition.
+    ///
+    /// - Parameter name: The name of the parameter being described.
+    /// - Parameter children: Block child elements.
+    init(name: String, children: BlockMarkup...) {
+        self.init(name: name, children: children)
+    }
+
+    /// The name of the parameter being described.
+    var name: String {
+        get {
+            guard case let .doxygenParam(name) = _data.raw.markup.data else {
+                fatalError("\(self) markup wrapped unexpected \(_data.raw)")
+            }
+            return name
+        }
+        set {
+            _data = _data.replacingSelf(.doxygenParam(
+                name: newValue,
+                parsedRange: nil,
+                _data.raw.markup.copyChildren()
+            ))
+        }
+    }
+}

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenParameter.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenParameter.swift
@@ -22,7 +22,7 @@ import Foundation
 /// For more information about transformation matrices, refer to the Transformation
 /// documentation.
 /// ```
-public struct DoxygenParam: BlockContainer {
+public struct DoxygenParameter: BlockContainer {
     public var _data: _MarkupData
 
     init(_ raw: RawMarkup) throws {
@@ -38,11 +38,11 @@ public struct DoxygenParam: BlockContainer {
     }
 
     public func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
-        return visitor.visitDoxygenParam(self)
+        return visitor.visitDoxygenParameter(self)
     }
 }
 
-public extension DoxygenParam {
+public extension DoxygenParameter {
     /// Create a new Doxygen parameter definition.
     ///
     /// - Parameter name: The name of the parameter being described.

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenParameter.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenParameter.swift
@@ -27,7 +27,7 @@ public struct DoxygenParameter: BlockContainer {
 
     init(_ raw: RawMarkup) throws {
         guard case .doxygenParam = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: BlockDirective.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: DoxygenParameter.self)
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenReturns.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenReturns.swift
@@ -10,7 +10,7 @@
 
 import Foundation
 
-/// A parsed Doxygen `\returns` command.
+/// A parsed Doxygen `\returns`, `\return`, or `\result` command.
 ///
 /// The Doxygen support in Swift-Markdown parses `\returns` commands of the form
 /// `\returns description`, where `description` continues until the next blank line or parsed

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenReturns.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenReturns.swift
@@ -1,0 +1,58 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+/// A parsed Doxygen `\returns` command.
+///
+/// The Doxygen support in Swift-Markdown parses `\returns` commands of the form
+/// `\returns description`, where `description` continues until the next blank line or parsed
+/// command. The commands `\return` and `\result` are also accepted, with the same format.
+///
+/// ```markdown
+/// \returns A freshly-created object.
+/// ```
+public struct DoxygenReturns: BlockContainer {
+    public var _data: _MarkupData
+
+    init(_ raw: RawMarkup) throws {
+        guard case .doxygenParam = raw.data else {
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: BlockDirective.self)
+        }
+        let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
+        self.init(_MarkupData(absoluteRaw))
+    }
+
+    init(_ data: _MarkupData) {
+        self._data = data
+    }
+
+    public func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
+        return visitor.visitDoxygenReturns(self)
+    }
+}
+
+public extension DoxygenReturns {
+    /// Create a new Doxygen parameter definition.
+    ///
+    /// - Parameter name: The name of the parameter being described.
+    /// - Parameter children: Block child elements.
+    init<Children: Sequence>(children: Children) where Children.Element == BlockMarkup {
+        try! self.init(.doxygenReturns(parsedRange: nil, children.map({ $0.raw.markup })))
+    }
+
+    /// Create a new Doxygen parameter definition.
+    ///
+    /// - Parameter name: The name of the parameter being described.
+    /// - Parameter children: Block child elements.
+    init(children: BlockMarkup...) {
+        self.init(children: children)
+    }
+}

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenReturns.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenReturns.swift
@@ -23,8 +23,8 @@ public struct DoxygenReturns: BlockContainer {
     public var _data: _MarkupData
 
     init(_ raw: RawMarkup) throws {
-        guard case .doxygenParam = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: BlockDirective.self)
+        guard case .doxygenReturns = raw.data else {
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: DoxygenReturns.self)
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))

--- a/Sources/Markdown/Markdown.docc/Markdown/BlockMarkup.md
+++ b/Sources/Markdown/Markdown.docc/Markdown/BlockMarkup.md
@@ -26,5 +26,6 @@
 
 ## See Also
 - <doc:BlockDirectives> 
+- <doc:DoxygenCommands>
 
 <!-- Copyright (c) 2021-2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/Markdown/Markdown.docc/Markdown/DoxygenCommands.md
+++ b/Sources/Markdown/Markdown.docc/Markdown/DoxygenCommands.md
@@ -1,0 +1,43 @@
+# Doxygen Commands
+
+Include a limited set of Doxygen commands in parsed Markdown.
+
+Swift Markdown includes an option to parse a limited set of Doxygen commands, to facilitate
+transitioning from a different Markdown parser. To include these commands in the output, include
+the options ``ParseOptions/parseBlockDirectives`` and ``ParseOptions/parseMinimalDoxygen`` when
+parsing a ``Document``. In the resulting document, parsed Doxygen commands appear as regular
+``Markup`` types in the hierarchy.
+
+## Parsing Strategy
+
+Doxygen commands are written by using either a backslash (`\`) or an at-sign (`@`) character,
+followed by the name of the command. Any parameters are then parsed as whitespace-separated words,
+then a "description" argument is taken from the remainder of the line, as well as all lines
+immediately after the command, until the parser sees a blank line, another Doxygen command, or a
+block directive. The description is then parsed for regular Markdown formatting, which is then
+stored as the children of the command type. For example, with Doxygen parsing turned on, the
+following document will parse three separate commands and one block directive:
+
+```markdown
+\param thing The thing.
+This is the thing that is modified.
+\param otherThing The other thing.
+
+\returns A thing that has been modified.
+@Comment {
+    This is not part of the `\returns` command.
+}
+```
+
+Doxygen commands are not parsed within code blocks or block directive content. No indentation
+adjustment is performed on paragraph arguments that span multiple lines, unlike with block directive
+content.
+
+## Topics
+
+### Commands
+
+- ``DoxygenParam``
+- ``DoxygenReturns``
+
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -223,6 +223,31 @@ struct PendingBlockDirective {
     }
 }
 
+struct PendingDoxygenCommand {
+    enum CommandKind {
+        case param(name: Substring)
+
+        var debugDescription: String {
+            switch self {
+            case .param(name: let name):
+                return "'param' Argument: '\(name)'"
+            }
+        }
+    }
+
+    var atLocation: SourceLocation
+
+    var nameLocation: SourceLocation
+
+    var kind: CommandKind
+
+    var endLocation: SourceLocation
+
+    mutating func addLine(_ line: TrimmedLine) {
+        endLocation = SourceLocation(line: line.lineNumber ?? 0, column: line.untrimmedText.count + 1, source: line.source)
+    }
+}
+
 struct TrimmedLine {
     /// A successful result of scanning for a prefix on a ``TrimmedLine``.
     struct Lex: Equatable {
@@ -459,8 +484,11 @@ private enum ParseContainer: CustomStringConvertible {
     /// A block directive container, which can contain other block directives or runs of lines.
     case blockDirective(PendingBlockDirective, [ParseContainer])
 
-    init<TrimmedLines: Sequence>(parsingHierarchyFrom trimmedLines: TrimmedLines) where TrimmedLines.Element == TrimmedLine {
-        self = ParseContainerStack(parsingHierarchyFrom: trimmedLines).top
+    /// A Doxygen command, which can contain arbitrary markup (but not block directives).
+    case doxygenCommand(PendingDoxygenCommand, [TrimmedLine])
+
+    init<TrimmedLines: Sequence>(parsingHierarchyFrom trimmedLines: TrimmedLines, options: ParseOptions) where TrimmedLines.Element == TrimmedLine {
+        self = ParseContainerStack(parsingHierarchyFrom: trimmedLines, options: options).top
     }
 
     var children: [ParseContainer] {
@@ -470,6 +498,8 @@ private enum ParseContainer: CustomStringConvertible {
         case .blockDirective(_, let children):
             return children
         case .lineRun:
+            return []
+        case .doxygenCommand:
             return []
         }
     }
@@ -545,6 +575,15 @@ private enum ParseContainer: CustomStringConvertible {
                     indent -= 4
                 }
                 print(children: children)
+            case .doxygenCommand(let pendingDoxygenCommand, let lines):
+                print("* Doxygen command \(pendingDoxygenCommand.kind.debugDescription)")
+                queueNewline()
+                indent += 4
+                for line in lines {
+                    print(line.text.debugDescription)
+                    queueNewline()
+                }
+                indent -= 4
             }
         }
     }
@@ -565,6 +604,9 @@ private enum ParseContainer: CustomStringConvertible {
         case .blockDirective(var pendingBlockDirective, let children):
             pendingBlockDirective.updateIndentation(for: line)
             self = .blockDirective(pendingBlockDirective, children)
+        case .doxygenCommand:
+            var newParent: ParseContainer? = nil
+            parent?.updateIndentation(under: &newParent, for: line)
         }
     }
 
@@ -609,6 +651,8 @@ private enum ParseContainer: CustomStringConvertible {
             return parent?.indentationAdjustment(under: nil) ?? 0
         case .blockDirective(let pendingBlockDirective, _):
             return pendingBlockDirective.indentationColumnCount
+        case .doxygenCommand:
+            return parent?.indentationAdjustment(under: nil) ?? 0
         }
     }
 
@@ -677,6 +721,15 @@ private enum ParseContainer: CustomStringConvertible {
                                     }),
                                     parsedRange: pendingBlockDirective.atLocation..<pendingBlockDirective.endLocation,
                                     children)]
+        case let .doxygenCommand(pendingDoxygenCommand, lines):
+            let range = pendingDoxygenCommand.atLocation..<pendingDoxygenCommand.endLocation
+            ranges.add(range)
+            let children = ParseContainer.lineRun(lines, isInCodeFence: false)
+                .convertToRawMarkup(ranges: &ranges, parent: self, options: options)
+            switch pendingDoxygenCommand.kind {
+            case .param(let name):
+                return [.doxygenParam(name: String(name), parsedRange: range, children)]
+            }
         }
     }
 }
@@ -689,8 +742,11 @@ struct ParseContainerStack {
     /// The stack of containers to be incrementally folded into a hierarchy.
     private var stack: [ParseContainer]
 
-    init<TrimmedLines: Sequence>(parsingHierarchyFrom trimmedLines: TrimmedLines) where TrimmedLines.Element == TrimmedLine {
+    private let options: ParseOptions
+
+    init<TrimmedLines: Sequence>(parsingHierarchyFrom trimmedLines: TrimmedLines, options: ParseOptions) where TrimmedLines.Element == TrimmedLine {
         self.stack = [.root([])]
+        self.options = options
         for line in trimmedLines {
             accept(line)
         }
@@ -706,6 +762,20 @@ struct ParseContainerStack {
             }
             return true
         } != nil
+    }
+
+    private var canParseDoxygenCommand: Bool {
+        guard options.contains(.parseMinimalDoxygen) else { return false }
+
+        guard !isInBlockDirective else { return false }
+
+        if case .blockDirective = top {
+            return false
+        } else if case .lineRun(_, isInCodeFence: let codeFence) = top {
+            return !codeFence
+        } else {
+            return true
+        }
     }
 
     private func isCodeFenceOrIndentedCodeBlock(on line: TrimmedLine) -> Bool {
@@ -760,21 +830,83 @@ struct ParseContainerStack {
         return pendingBlockDirective
     }
 
+    private func parseDoxygenCommandOpening(on line: TrimmedLine) -> (pendingCommand: PendingDoxygenCommand, remainder: TrimmedLine)? {
+        guard canParseDoxygenCommand else { return nil }
+        guard !isCodeFenceOrIndentedCodeBlock(on: line) else { return nil }
+
+        var remainder = line
+        guard let at = remainder.lex(until: { ch in
+            switch ch {
+            case "@", "\\":
+                return .continue
+            default:
+                return .stop
+            }
+        }) else { return nil }
+        guard let name = remainder.lex(until: { ch in
+            if ch.isWhitespace {
+                return .stop
+            } else {
+                return .continue
+            }
+        }) else { return nil }
+        remainder.lexWhitespace()
+
+        switch name.text.lowercased() {
+        case "param":
+            guard let paramName = remainder.lex(until: { ch in
+                if ch.isWhitespace {
+                    return .stop
+                } else {
+                    return .continue
+                }
+            }) else { return nil }
+            remainder.lexWhitespace()
+            var pendingCommand = PendingDoxygenCommand(
+                atLocation: at.range!.lowerBound,
+                nameLocation: name.range!.lowerBound,
+                kind: .param(name: paramName.text),
+                endLocation: name.range!.upperBound)
+            pendingCommand.addLine(remainder)
+            return (pendingCommand, remainder)
+        default:
+            return nil
+        }
+    }
+
     /// Accept a trimmed line, opening new block directives as indicated by the source,
     /// closing a block directive if applicable, or adding the line to a run of lines to be parsed
     /// as Markdown later.
     private mutating func accept(_ line: TrimmedLine) {
-        if line.isEmptyOrAllWhitespace,
-           case let .blockDirective(pendingBlockDirective, _) = top {
-            switch pendingBlockDirective.parseState {
-            case .argumentsStart,
-                 .contentsStart,
-                 .done:
-                closeTop()
+        if line.isEmptyOrAllWhitespace {
+            switch top {
+            case let .blockDirective(pendingBlockDirective, _):
+                switch pendingBlockDirective.parseState {
+                case .argumentsStart,
+                     .contentsStart,
+                     .done:
+                    closeTop()
 
+                default:
+                    break
+                }
+            case .doxygenCommand:
+                closeTop()
             default:
                 break
             }
+        }
+
+        // If we can parse a Doxygen command from this line, start one and skip everything else.
+        if let result = parseDoxygenCommandOpening(on: line) {
+            switch top {
+            case .root:
+                break
+            default:
+                closeTop()
+            }
+            push(.doxygenCommand(result.pendingCommand, [result.remainder]))
+            return
         }
 
         // If we're inside a block directive, check to see whether we need to update its
@@ -822,7 +954,7 @@ struct ParseContainerStack {
             switch top {
             case .root:
                 push(.blockDirective(newBlockDirective, []))
-            case .lineRun:
+            case .lineRun, .doxygenCommand:
                 closeTop()
                 push(.blockDirective(newBlockDirective, []))
             case .blockDirective(let previousBlockDirective, _):
@@ -848,11 +980,16 @@ struct ParseContainerStack {
         } else {
             switch top {
             case .root:
-                push(.lineRun([line], isInCodeFence: false))
+                push(.lineRun([line], isInCodeFence: line.isProbablyCodeFence))
             case .lineRun(var lines, let isInCodeFence):
                 pop()
                 lines.append(line)
                 push(.lineRun(lines, isInCodeFence: isInCodeFence != line.isProbablyCodeFence))
+            case .doxygenCommand(var pendingDoxygenCommand, var lines):
+                pop()
+                lines.append(line)
+                pendingDoxygenCommand.addLine(line)
+                push(.doxygenCommand(pendingDoxygenCommand, lines))
             case .blockDirective(var pendingBlockDirective, let children):
                 // A pending block directive can accept this line if it is in the middle of
                 // parsing arguments text (to allow indentation to align arguments) or
@@ -923,6 +1060,8 @@ struct ParseContainerStack {
             push(.blockDirective(pendingBlockDirective, children))
         case .lineRun:
             fatalError("Line runs cannot have children")
+        case .doxygenCommand:
+            fatalError("Doxygen commands cannot have children")
         }
     }
 
@@ -985,7 +1124,7 @@ struct BlockDirectiveParser {
         // Phase 1: Categorize the lines into a hierarchy of block containers by parsing the prefix
         // of the line, opening and closing block directives appropriately, and folding elements
         // into a root document.
-        let rootContainer = ParseContainer(parsingHierarchyFrom: trimmedLines)
+        let rootContainer = ParseContainer(parsingHierarchyFrom: trimmedLines, options: options)
 
         // Phase 2: Convert the hierarchy of block containers into a real ``Document``.
         // This is where the CommonMark parser is called upon to parse runs of lines of content,

--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -675,10 +675,11 @@ private enum ParseContainer: CustomStringConvertible {
             // We need to keep track of what we removed because cmark will report different source locations than what we
             // had in the source. We'll adjust those when we get them back.
             let trimmedIndentationAndLines = lines.map { line -> (line: TrimmedLine,
-                                                                  indentation: TrimmedLine.Lex?) in
+                                                                  indentation: Int) in
                 var trimmedLine = line
                 let trimmedWhitespace = trimmedLine.lexWhitespace(maxLength: indentationColumnCount)
-                return (trimmedLine, trimmedWhitespace)
+                let indentation = (trimmedWhitespace?.text.count ?? 0) + line.untrimmedText.distance(from: line.untrimmedText.startIndex, to: line.parseIndex)
+                return (trimmedLine, indentation)
             }
 
             // Build the logical block of text that cmark will see.

--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -226,11 +226,14 @@ struct PendingBlockDirective {
 struct PendingDoxygenCommand {
     enum CommandKind {
         case param(name: Substring)
+        case returns
 
         var debugDescription: String {
             switch self {
             case .param(name: let name):
                 return "'param' Argument: '\(name)'"
+            case .returns:
+                return "'returns'"
             }
         }
     }
@@ -730,6 +733,8 @@ private enum ParseContainer: CustomStringConvertible {
             switch pendingDoxygenCommand.kind {
             case .param(let name):
                 return [.doxygenParam(name: String(name), parsedRange: range, children)]
+            case .returns:
+                return [.doxygenReturns(parsedRange: range, children)]
             }
         }
     }
@@ -867,6 +872,14 @@ struct ParseContainerStack {
                 atLocation: at.range!.lowerBound,
                 nameLocation: name.range!.lowerBound,
                 kind: .param(name: paramName.text),
+                endLocation: name.range!.upperBound)
+            pendingCommand.addLine(remainder)
+            return (pendingCommand, remainder)
+        case "return", "returns", "result":
+            var pendingCommand = PendingDoxygenCommand(
+                atLocation: at.range!.lowerBound,
+                nameLocation: name.range!.lowerBound,
+                kind: .returns,
                 endLocation: name.range!.upperBound)
             pendingCommand.addLine(remainder)
             return (pendingCommand, remainder)

--- a/Sources/Markdown/Parser/ParseOptions.swift
+++ b/Sources/Markdown/Parser/ParseOptions.swift
@@ -24,5 +24,8 @@ public struct ParseOptions: OptionSet {
     
     /// Disable converting straight quotes to curly, --- to em dashes, -- to en dashes during parsing
     public static let disableSmartOpts = ParseOptions(rawValue: 1 << 2)
+
+    /// Parse a limited set of Doxygen commands. Requires ``parseBlockDirectives``.
+    public static let parseMinimalDoxygen = ParseOptions(rawValue: 1 << 3)
 }
 

--- a/Sources/Markdown/Parser/RangeAdjuster.swift
+++ b/Sources/Markdown/Parser/RangeAdjuster.swift
@@ -19,7 +19,7 @@ struct RangeAdjuster: MarkupWalker {
 
     /// An array of whitespace spans that were removed for each line, indexed
     /// by line number. `nil` means that no whitespace was removed on that line.
-    var trimmedIndentationPerLine: [TrimmedLine.Lex?]
+    var trimmedIndentationPerLine: [Int]
 
     mutating func defaultVisit(_ markup: Markup) {
         /// This should only be used in the parser where ranges are guaranteed
@@ -27,10 +27,10 @@ struct RangeAdjuster: MarkupWalker {
         let adjustedRange = markup.range.map { range -> SourceRange in
             // Add back the offset to the column as if the indentation weren't stripped.
             let start = SourceLocation(line: startLine + range.lowerBound.line - 1,
-                                       column: range.lowerBound.column + (trimmedIndentationPerLine[range.lowerBound.line - 1]?.text.count ?? 0),
+                                       column: range.lowerBound.column + (trimmedIndentationPerLine[range.lowerBound.line - 1] ),
                                        source: range.lowerBound.source)
             let end = SourceLocation(line: startLine + range.upperBound.line - 1,
-                                     column: range.upperBound.column + (trimmedIndentationPerLine[range.upperBound.line - 1]?.text.count ?? 0),
+                                     column: range.upperBound.column + (trimmedIndentationPerLine[range.upperBound.line - 1]),
                                      source: range.upperBound.source)
             return start..<end
         }

--- a/Sources/Markdown/Visitor/MarkupVisitor.swift
+++ b/Sources/Markdown/Visitor/MarkupVisitor.swift
@@ -274,6 +274,14 @@ public protocol MarkupVisitor {
     - returns: The result of the visit.
      */
      mutating func visitInlineAttributes(_ attributes: InlineAttributes) -> Result
+
+    /**
+     Visit a `DoxygenParam` element and return the result.
+
+     - parameter doxygenParam: A `DoxygenParam` element.
+     - returns: The result of the visit.
+     */
+    mutating func visitDoxygenParam(_ doxygenParam: DoxygenParam) -> Result
 }
 
 extension MarkupVisitor {
@@ -372,5 +380,8 @@ extension MarkupVisitor {
     }
     public mutating func visitInlineAttributes(_ attributes: InlineAttributes) -> Result {
         return defaultVisit(attributes)
+    }
+    public mutating func visitDoxygenParam(_ doxygenParam: DoxygenParam) -> Result {
+        return defaultVisit(doxygenParam)
     }
 }

--- a/Sources/Markdown/Visitor/MarkupVisitor.swift
+++ b/Sources/Markdown/Visitor/MarkupVisitor.swift
@@ -281,7 +281,7 @@ public protocol MarkupVisitor {
      - parameter doxygenParam: A `DoxygenParam` element.
      - returns: The result of the visit.
      */
-    mutating func visitDoxygenParam(_ doxygenParam: DoxygenParam) -> Result
+    mutating func visitDoxygenParameter(_ doxygenParam: DoxygenParameter) -> Result
 
     /**
      Visit a `DoxygenReturns` element and return the result.
@@ -389,7 +389,7 @@ extension MarkupVisitor {
     public mutating func visitInlineAttributes(_ attributes: InlineAttributes) -> Result {
         return defaultVisit(attributes)
     }
-    public mutating func visitDoxygenParam(_ doxygenParam: DoxygenParam) -> Result {
+    public mutating func visitDoxygenParameter(_ doxygenParam: DoxygenParameter) -> Result {
         return defaultVisit(doxygenParam)
     }
     public mutating func visitDoxygenReturns(_ doxygenReturns: DoxygenReturns) -> Result {

--- a/Sources/Markdown/Visitor/MarkupVisitor.swift
+++ b/Sources/Markdown/Visitor/MarkupVisitor.swift
@@ -282,6 +282,14 @@ public protocol MarkupVisitor {
      - returns: The result of the visit.
      */
     mutating func visitDoxygenParam(_ doxygenParam: DoxygenParam) -> Result
+
+    /**
+     Visit a `DoxygenReturns` element and return the result.
+
+     - parameter doxygenReturns: A `DoxygenReturns` element.
+     - returns: The result of the visit.
+     */
+    mutating func visitDoxygenReturns(_ doxygenReturns: DoxygenReturns) -> Result
 }
 
 extension MarkupVisitor {
@@ -383,5 +391,8 @@ extension MarkupVisitor {
     }
     public mutating func visitDoxygenParam(_ doxygenParam: DoxygenParam) -> Result {
         return defaultVisit(doxygenParam)
+    }
+    public mutating func visitDoxygenReturns(_ doxygenReturns: DoxygenReturns) -> Result {
+        return defaultVisit(doxygenReturns)
     }
 }

--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -230,6 +230,15 @@ public struct MarkupFormatter: MarkupWalker {
             }
         }
 
+        /// The character to use when formatting Doxygen commands.
+        public enum DoxygenCommandPrefix: String, CaseIterable {
+            /// Precede Doxygen commands with a backslash (`\`).
+            case backslash = "\\"
+
+            /// Precede Doxygen commands with an at-sign (`@`).
+            case at = "@"
+        }
+
         // MARK: Option Properties
 
         var orderedListNumerals: OrderedListNumerals
@@ -243,6 +252,7 @@ public struct MarkupFormatter: MarkupWalker {
         var preferredHeadingStyle: PreferredHeadingStyle
         var preferredLineLimit: PreferredLineLimit?
         var customLinePrefix: String
+        var doxygenCommandPrefix: DoxygenCommandPrefix
 
         /**
          Create a set of formatting options to use when printing an element.
@@ -270,7 +280,8 @@ public struct MarkupFormatter: MarkupWalker {
                     condenseAutolinks: Bool = true,
                     preferredHeadingStyle: PreferredHeadingStyle = .atx,
                     preferredLineLimit: PreferredLineLimit? = nil,
-                    customLinePrefix: String = "") {
+                    customLinePrefix: String = "",
+                    doxygenCommandPrefix: DoxygenCommandPrefix = .backslash) {
             self.unorderedListMarker = unorderedListMarker
             self.orderedListNumerals = orderedListNumerals
             self.useCodeFence = useCodeFence
@@ -284,6 +295,7 @@ public struct MarkupFormatter: MarkupWalker {
             // three characters long.
             self.thematicBreakLength = max(3, thematicBreakLength)
             self.customLinePrefix = customLinePrefix
+            self.doxygenCommandPrefix = doxygenCommandPrefix
         }
 
         /// The default set of formatting options.
@@ -1143,5 +1155,17 @@ public struct MarkupFormatter: MarkupWalker {
             queueNewline()
             printInlineAttributes()
         }
+    }
+
+    public mutating func visitDoxygenParameter(_ doxygenParam: DoxygenParameter) -> () {
+        print("\(formattingOptions.doxygenCommandPrefix.rawValue)param", for: doxygenParam)
+        print(" \(doxygenParam.name) ", for: doxygenParam)
+        descendInto(doxygenParam)
+    }
+
+    public mutating func visitDoxygenReturns(_ doxygenReturns: DoxygenReturns) -> () {
+        // FIXME: store the actual command name used in the original markup
+        print("\(formattingOptions.doxygenCommandPrefix.rawValue)returns ", for: doxygenReturns)
+        descendInto(doxygenReturns)
     }
 }

--- a/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
@@ -287,7 +287,7 @@ struct MarkupTreeDumper: MarkupWalker {
         dump(attributes, customDescription: "attributes: `\(attributes.attributes)`")
     }
 
-    mutating func visitDoxygenParam(_ doxygenParam: DoxygenParam) -> () {
+    mutating func visitDoxygenParameter(_ doxygenParam: DoxygenParameter) -> () {
         dump(doxygenParam, customDescription: "parameter: \(doxygenParam.name)")
     }
 }

--- a/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
@@ -286,4 +286,8 @@ struct MarkupTreeDumper: MarkupWalker {
     mutating func visitInlineAttributes(_ attributes: InlineAttributes) -> () {
         dump(attributes, customDescription: "attributes: `\(attributes.attributes)`")
     }
+
+    mutating func visitDoxygenParam(_ doxygenParam: DoxygenParam) -> () {
+        dump(doxygenParam, customDescription: "parameter: \(doxygenParam.name)")
+    }
 }

--- a/Sources/markdown-tool/Commands/DumpTreeCommand.swift
+++ b/Sources/markdown-tool/Commands/DumpTreeCommand.swift
@@ -28,8 +28,18 @@ extension MarkdownCommand {
         @Flag<Bool>(inversion: .prefixedNo, exclusivity: .chooseLast, help: "Parse block directives")
         var parseBlockDirectives: Bool = false
 
+        @Flag<Bool>(inversion: .prefixedNo, exclusivity: .chooseLast, help: "Parse a minimal set of Doxygen commands (requires --parse-block-directives)")
+        var experimentalParseDoxygenCommands: Bool = false
+
         func run() throws {
-            let parseOptions: ParseOptions = parseBlockDirectives ? [.parseBlockDirectives] : []
+            var parseOptions = ParseOptions()
+            if parseBlockDirectives {
+                parseOptions.insert(.parseBlockDirectives)
+            }
+            if experimentalParseDoxygenCommands {
+                parseOptions.insert(.parseMinimalDoxygen)
+            }
+
             let document: Document
             if let inputFilePath = inputFilePath {
                 (_, document) = try MarkdownCommand.parseFile(at: inputFilePath, options: parseOptions)

--- a/Tests/MarkdownTests/Parsing/DoxygenCommandParserTests.swift
+++ b/Tests/MarkdownTests/Parsing/DoxygenCommandParserTests.swift
@@ -170,8 +170,8 @@ class DoxygenCommandParserTests: XCTestCase {
         let expectedDump = """
         Document @1:1-2:39
         └─ DoxygenParam @1:1-2:39 parameter: thing
-           └─ Paragraph @1:1-2:39
-              ├─ Text @1:1-1:11 "The thing."
+           └─ Paragraph @1:14-2:39
+              ├─ Text @1:14-1:24 "The thing."
               ├─ SoftBreak
               └─ Text @2:1-2:39 "This is the thing that is messed with."
         """

--- a/Tests/MarkdownTests/Parsing/DoxygenCommandParserTests.swift
+++ b/Tests/MarkdownTests/Parsing/DoxygenCommandParserTests.swift
@@ -32,6 +32,28 @@ class DoxygenCommandParserTests: XCTestCase {
         XCTAssertEqual(document.debugDescription(), expectedDump)
     }
 
+    func testParseReturns() {
+        func assertValidParse(source: String) {
+            let document = Document(parsing: source, options: parseOptions)
+            XCTAssert(document.child(at: 0) is DoxygenReturns)
+
+            let expectedDump = """
+            Document
+            └─ DoxygenReturns
+               └─ Paragraph
+                  └─ Text "The thing."
+            """
+            XCTAssertEqual(document.debugDescription(), expectedDump)
+        }
+
+        assertValidParse(source: "@returns The thing.")
+        assertValidParse(source: "@return The thing.")
+        assertValidParse(source: "@result The thing.")
+        assertValidParse(source: #"\returns The thing."#)
+        assertValidParse(source: #"\return The thing."#)
+        assertValidParse(source: #"\result The thing."#)
+    }
+
     func testParseParamWithSlash() throws {
         let source = #"""
         \param thing The thing.

--- a/Tests/MarkdownTests/Parsing/DoxygenCommandParserTests.swift
+++ b/Tests/MarkdownTests/Parsing/DoxygenCommandParserTests.swift
@@ -20,12 +20,12 @@ class DoxygenCommandParserTests: XCTestCase {
         """
 
         let document = Document(parsing: source, options: parseOptions)
-        let param = try XCTUnwrap(document.child(at: 0) as? DoxygenParam)
+        let param = try XCTUnwrap(document.child(at: 0) as? DoxygenParameter)
         XCTAssertEqual(param.name, "thing")
 
         let expectedDump = """
         Document
-        └─ DoxygenParam parameter: thing
+        └─ DoxygenParameter parameter: thing
            └─ Paragraph
               └─ Text "The thing."
         """
@@ -60,12 +60,12 @@ class DoxygenCommandParserTests: XCTestCase {
         """#
 
         let document = Document(parsing: source, options: parseOptions)
-        let param = try XCTUnwrap(document.child(at: 0) as? DoxygenParam)
+        let param = try XCTUnwrap(document.child(at: 0) as? DoxygenParameter)
         XCTAssertEqual(param.name, "thing")
 
         let expectedDump = """
         Document
-        └─ DoxygenParam parameter: thing
+        └─ DoxygenParameter parameter: thing
            └─ Paragraph
               └─ Text "The thing."
         """
@@ -82,7 +82,7 @@ class DoxygenCommandParserTests: XCTestCase {
 
         let expectedDump = """
         Document
-        └─ DoxygenParam parameter: thing
+        └─ DoxygenParameter parameter: thing
            └─ Paragraph
               ├─ Text "The thing."
               ├─ SoftBreak
@@ -102,7 +102,7 @@ class DoxygenCommandParserTests: XCTestCase {
 
         let expectedDump = """
         Document
-        ├─ DoxygenParam parameter: thing
+        ├─ DoxygenParameter parameter: thing
         │  └─ Paragraph
         │     └─ Text "The thing."
         └─ Paragraph
@@ -125,10 +125,10 @@ class DoxygenCommandParserTests: XCTestCase {
         Document
         ├─ Paragraph
         │  └─ Text "Messes with the thing."
-        ├─ DoxygenParam parameter: thing
+        ├─ DoxygenParameter parameter: thing
         │  └─ Paragraph
         │     └─ Text "The thing."
-        └─ DoxygenParam parameter: otherThing
+        └─ DoxygenParameter parameter: otherThing
            └─ Paragraph
               └─ Text "The other thing."
         """
@@ -151,7 +151,7 @@ class DoxygenCommandParserTests: XCTestCase {
         Document
         ├─ Paragraph
         │  └─ Text "Messes with the thing."
-        ├─ DoxygenParam parameter: thing
+        ├─ DoxygenParameter parameter: thing
         │  └─ Paragraph
         │     └─ Text "The thing."
         └─ BlockDirective name: "Comment"
@@ -173,7 +173,7 @@ class DoxygenCommandParserTests: XCTestCase {
         Document
         ├─ Paragraph
         │  └─ Text "This is a paragraph."
-        └─ DoxygenParam parameter: thing
+        └─ DoxygenParameter parameter: thing
            └─ Paragraph
               └─ Text "The thing."
         """
@@ -191,7 +191,7 @@ class DoxygenCommandParserTests: XCTestCase {
         // FIXME: The source location for the first description line is wrong
         let expectedDump = """
         Document @1:1-2:39
-        └─ DoxygenParam @1:1-2:39 parameter: thing
+        └─ DoxygenParameter @1:1-2:39 parameter: thing
            └─ Paragraph @1:14-2:39
               ├─ Text @1:14-1:24 "The thing."
               ├─ SoftBreak

--- a/Tests/MarkdownTests/Parsing/DoxygenCommandParserTests.swift
+++ b/Tests/MarkdownTests/Parsing/DoxygenCommandParserTests.swift
@@ -1,0 +1,281 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+@testable import Markdown
+import XCTest
+
+class DoxygenCommandParserTests: XCTestCase {
+    let parseOptions: ParseOptions = [.parseMinimalDoxygen, .parseBlockDirectives]
+
+    func testParseParam() throws {
+        let source = """
+        @param thing The thing.
+        """
+
+        let document = Document(parsing: source, options: parseOptions)
+        let param = try XCTUnwrap(document.child(at: 0) as? DoxygenParam)
+        XCTAssertEqual(param.name, "thing")
+
+        let expectedDump = """
+        Document
+        └─ DoxygenParam parameter: thing
+           └─ Paragraph
+              └─ Text "The thing."
+        """
+        XCTAssertEqual(document.debugDescription(), expectedDump)
+    }
+
+    func testParseParamWithSlash() throws {
+        let source = #"""
+        \param thing The thing.
+        """#
+
+        let document = Document(parsing: source, options: parseOptions)
+        let param = try XCTUnwrap(document.child(at: 0) as? DoxygenParam)
+        XCTAssertEqual(param.name, "thing")
+
+        let expectedDump = """
+        Document
+        └─ DoxygenParam parameter: thing
+           └─ Paragraph
+              └─ Text "The thing."
+        """
+        XCTAssertEqual(document.debugDescription(), expectedDump)
+    }
+
+    func testParseMultilineDescription() {
+        let source = """
+        @param thing The thing.
+        This is the thing that is messed with.
+        """
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        let expectedDump = """
+        Document
+        └─ DoxygenParam parameter: thing
+           └─ Paragraph
+              ├─ Text "The thing."
+              ├─ SoftBreak
+              └─ Text "This is the thing that is messed with."
+        """
+        XCTAssertEqual(document.debugDescription(), expectedDump)
+    }
+
+    func testBreakDescriptionWithBlankLine() {
+        let source = """
+        @param thing The thing.
+
+        Messes with the thing.
+        """
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        let expectedDump = """
+        Document
+        ├─ DoxygenParam parameter: thing
+        │  └─ Paragraph
+        │     └─ Text "The thing."
+        └─ Paragraph
+           └─ Text "Messes with the thing."
+        """
+        XCTAssertEqual(document.debugDescription(), expectedDump)
+    }
+
+    func testBreakDescriptionWithOtherCommand() {
+        let source = """
+        Messes with the thing.
+
+        @param thing The thing.
+        @param otherThing The other thing.
+        """
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        let expectedDump = """
+        Document
+        ├─ Paragraph
+        │  └─ Text "Messes with the thing."
+        ├─ DoxygenParam parameter: thing
+        │  └─ Paragraph
+        │     └─ Text "The thing."
+        └─ DoxygenParam parameter: otherThing
+           └─ Paragraph
+              └─ Text "The other thing."
+        """
+        XCTAssertEqual(document.debugDescription(), expectedDump)
+    }
+
+    func testBreakDescriptionWithBlockDirective() {
+        let source = """
+        Messes with the thing.
+
+        @param thing The thing.
+        @Comment {
+            This is supposed to be different from the above command.
+        }
+        """
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        let expectedDump = """
+        Document
+        ├─ Paragraph
+        │  └─ Text "Messes with the thing."
+        ├─ DoxygenParam parameter: thing
+        │  └─ Paragraph
+        │     └─ Text "The thing."
+        └─ BlockDirective name: "Comment"
+           └─ Paragraph
+              └─ Text "This is supposed to be different from the above command."
+        """
+        XCTAssertEqual(document.debugDescription(), expectedDump)
+    }
+
+    func testCommandBreaksParagraph() {
+        let source = """
+        This is a paragraph.
+        @param thing The thing.
+        """
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        let expectedDump = """
+        Document
+        ├─ Paragraph
+        │  └─ Text "This is a paragraph."
+        └─ DoxygenParam parameter: thing
+           └─ Paragraph
+              └─ Text "The thing."
+        """
+        XCTAssertEqual(document.debugDescription(), expectedDump)
+    }
+
+    func testSourceLocations() {
+        let source = """
+        @param thing The thing.
+        This is the thing that is messed with.
+        """
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        // FIXME: The source location for the first description line is wrong
+        let expectedDump = """
+        Document @1:1-2:39
+        └─ DoxygenParam @1:1-2:39 parameter: thing
+           └─ Paragraph @1:1-2:39
+              ├─ Text @1:1-1:11 "The thing."
+              ├─ SoftBreak
+              └─ Text @2:1-2:39 "This is the thing that is messed with."
+        """
+        XCTAssertEqual(document.debugDescription(options: .printSourceLocations), expectedDump)
+    }
+
+    func testDoesNotParseWithoutOption() {
+        do {
+            let source = """
+            @param thing The thing.
+            """
+
+            let document = Document(parsing: source, options: .parseBlockDirectives)
+
+            let expectedDump = """
+            Document
+            └─ BlockDirective name: "param"
+            """
+            XCTAssertEqual(document.debugDescription(), expectedDump)
+        }
+
+        do {
+            let source = """
+            @param thing The thing.
+            """
+
+            let document = Document(parsing: source)
+
+            let expectedDump = """
+            Document
+            └─ Paragraph
+               └─ Text "@param thing The thing."
+            """
+            XCTAssertEqual(document.debugDescription(), expectedDump)
+        }
+    }
+
+    func testDoesNotParseInsideBlockDirective() {
+        let source = """
+        @Comment {
+            @param thing The thing.
+        }
+        """
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        let expectedDump = """
+        Document
+        └─ BlockDirective name: "Comment"
+           └─ BlockDirective name: "param"
+        """
+        XCTAssertEqual(document.debugDescription(), expectedDump)
+    }
+
+    func testDoesNotParseInsideCodeBlock() {
+        do {
+            let source = """
+            ```
+            @param thing The thing.
+            ```
+            """
+
+            let document = Document(parsing: source, options: parseOptions)
+
+            let expectedDump = """
+            Document
+            └─ CodeBlock language: none
+               @param thing The thing.
+            """
+            XCTAssertEqual(document.debugDescription(), expectedDump)
+        }
+
+        do {
+            let source = """
+            Paragraph to set indentation.
+
+                @param thing The thing.
+            """
+
+            let document = Document(parsing: source, options: parseOptions)
+
+            let expectedDump = """
+            Document
+            ├─ Paragraph
+            │  └─ Text "Paragraph to set indentation."
+            └─ CodeBlock language: none
+               @param thing The thing.
+            """
+            XCTAssertEqual(document.debugDescription(), expectedDump)
+        }
+    }
+
+    func testDoesNotParseUnknownCommand() {
+        let source = #"""
+        \unknown
+        """#
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        let expectedDump = #"""
+        Document
+        └─ Paragraph
+           └─ Text "\unknown"
+        """#
+        XCTAssertEqual(document.debugDescription(), expectedDump)
+    }
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://69835334

## Summary

This PR introduces a new parser mode, adding support for a minimal set of Doxygen commands, to facilitate transitioning from alternate documentation systems into systems that use Swift-Markdown, such as Swift-DocC.

The parsing is gated behind a new parse option, currently named `parseMinimalDoxygen` (name open for bikeshedding). When both this and `parseBlockDirectives` are given, the block-directive parser will start looking for a specific set of Doxygen commands. This PR adds support for two basic commands: `\param` and `\returns` (though the latter will also recognize `\return` and `\result`, as those are synonyms in Doxygen itself).

To facilitate testing, this PR also extends the `markdown-tool dump-tree` command with an `--experimental-parse-doxygen-commands` flag which turns on the behavior.

I also fixed two other issues in the block directive parser in the course of this PR:

- If a document begins with a code fence, the contents of that code fence were incorrectly scanned for block directives.
- If a line run in a document or block directive included a line that didn't start on the beginning of the line (e.g. when a directive is written on one line), the source location was incorrectly given as the beginning of the line.

## Dependencies

This requires another PR to integrate with Swift-DocC, which is yet to be written.

## Testing

As the new functionality is gated behind a new ParseOption, testing should also ensure that existing functionality is not changed without the new option set.

Steps:
1. Write a Markdown file with Doxygen command content in it. See the tests added in this PR for examples.
2. `swift run markdown-tool dump-tree --parse-block-directives --experimental-parse-doxygen-commands test.md`
3. Inspect the result to ensure that it looks valid.
4. Repeat with `--source-locations` and ensure that the source locations for command descriptions look valid.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
