### PR TITLE
Revert "Add isAutolink property to Link"

### DIFF
--- a/Sources/Markdown/Inline Nodes/Inline Containers/Link.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/Link.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -61,16 +61,6 @@ public extension Link {
                 _data = _data.replacingSelf(.link(destination: newValue, parsedRange: nil, _data.raw.markup.copyChildren()))
             }
         }
-    }
-
-    var isAutolink: Bool {
-        guard let destination,
-              childCount == 1,
-              let text = child(at: 0) as? Text,
-              destination == text.string else {
-            return false
-        }
-        return true
     }
 
     // MARK: Visitation

--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -819,8 +819,11 @@ public struct MarkupFormatter: MarkupWalker {
     public mutating func visitLink(_ link: Link) {
         let savedState = state
         if formattingOptions.condenseAutolinks,
-           link.isAutolink,
-           let destination = link.destination {
+            let destination = link.destination,
+        link.childCount == 1,
+        let text = link.child(at: 0) as? Text,
+            // Print autolink-style
+            destination == text.string {
             print("<\(destination)>", for: link)
         } else {
             func printRegularLink() {

--- a/Tests/MarkdownTests/Inline Nodes/LinkTests.swift
+++ b/Tests/MarkdownTests/Inline Nodes/LinkTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -33,19 +33,5 @@ class LinkTests: XCTestCase {
             └─ Text "Hello, world!"
             """
         XCTAssertEqual(expectedDump, link.debugDescription())
-    }
-    
-    func testAutoLink() {
-        let children = [Text("example.com")]
-        var link = Link(destination: "example.com", children)
-        let expectedDump = """
-            Link destination: "example.com"
-            └─ Text "example.com"
-            """
-        XCTAssertEqual(expectedDump, link.debugDescription())
-        XCTAssertTrue(link.isAutolink)
-        
-        link.destination = "test.example.com"
-        XCTAssertFalse(link.isAutolink)
     }
 }


### PR DESCRIPTION
Reverts apple/swift-markdown#110

This change breaks PR testing in Swift-DocC. I'm reverting it so that i can re-merge it with a fix.