### PR TITLE
use older `if let` syntax in Link.isAutolink

### DIFF
--- a/Sources/Markdown/Inline Nodes/Inline Containers/Link.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/Link.swift
@@ -64,7 +64,7 @@ public extension Link {
     }
 
     var isAutolink: Bool {
-        guard let destination,
+        guard let destination = destination,
               childCount == 1,
               let text = child(at: 0) as? Text,
               destination == text.string else {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://106666684

## Summary

The `Link.isAutolink` property added in https://github.com/apple/swift-markdown/pull/110 used the newer `if let binding` syntax added in Swift 5.8. However, PR testing in Swift-DocC is done with Swift 5.5, causing the PR test to fail. This PR "downgrades" the syntax in the `isAutolink` property getter to ensure compatibility with Swift 5.5.

## Dependencies

None

## Testing

Ensure this branch builds with Swift 5.5, for example using the [`swift:5.5-focal`](https://hub.docker.com/layers/library/swift/5.5-focal/images/sha256-16160d06a6700f639715864e868f0efcb37cbf4b3ccc68c3fb48e6552172462b?context=explore) Docker image.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
