### PR TITLE
don't try to add a line to a closed block directive

### DIFF
--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -1009,7 +1009,10 @@ struct ParseContainerStack {
                 // A pending block directive can accept this line if it is in the middle of
                 // parsing arguments text (to allow indentation to align arguments) or
                 // if the line isn't taking part in a code block.
-                let canAcceptLine = pendingBlockDirective.parseState == .argumentsText || !isCodeFenceOrIndentedCodeBlock(on: line)
+                let canAcceptLine =
+                    pendingBlockDirective.parseState != .done &&
+                    (pendingBlockDirective.parseState == .argumentsText ||
+                     !isCodeFenceOrIndentedCodeBlock(on: line))
                 if canAcceptLine && pendingBlockDirective.accept(line) {
                     pop()
                     push(.blockDirective(pendingBlockDirective, children))

--- a/Tests/MarkdownTests/Parsing/BlockDirectiveParserTests.swift
+++ b/Tests/MarkdownTests/Parsing/BlockDirectiveParserTests.swift
@@ -991,7 +991,7 @@ class BlockDirectiveArgumentParserTests: XCTestCase {
         }
         """
         let document = Document(parsing: source, options: [.parseBlockDirectives])
-
+        
         let expectedDump = #"""
         Document @1:1-4:2
         ├─ BlockDirective @1:1-1:19 name: "blah"
@@ -1000,6 +1000,23 @@ class BlockDirectiveArgumentParserTests: XCTestCase {
         └─ BlockDirective @2:1-4:2 name: "blah"
            └─ Paragraph @3:5-3:12
               └─ Text @3:5-3:12 "content"
+        """#
+        XCTAssertEqual(document.debugDescription(options: .printSourceLocations), expectedDump)
+    }
+
+    func testSingleLineDirectiveWithTrailingContent() {
+        let source = """
+        @blah { content }
+        content
+        """
+        let document = Document(parsing: source, options: [.parseBlockDirectives])
+        let expectedDump = #"""
+        Document @1:1-2:8
+        ├─ BlockDirective @1:1-1:18 name: "blah"
+        │  └─ Paragraph @1:9-1:16
+        │     └─ Text @1:9-1:16 "content"
+        └─ Paragraph @2:1-2:8
+           └─ Text @2:1-2:8 "content"
         """#
         XCTAssertEqual(document.debugDescription(options: .printSourceLocations), expectedDump)
     }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://105221177

## Summary

When a single-line block directive is parsed, it is added to the parse stack in a `.done` state. If the next line is regular content, it then tries to add this line to the block directive. This trips an assertion, `"A closed block directive container cannot accept further lines of content."`. This PR tweaks the directive parser by making it treat a block directive in a `.done` state as not being able to accept further lines of contents.

## Dependencies

None

## Testing

```
@blah { content }
content
```

Steps:
1. Save the above markdown as `test.md`.
2. `swift run markdown-tool dump-tree --parse-block-directives test.md`
3. Ensure that the debug tree is printed correctly without crashing.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
