### PR TITLE
trim trailing whitespace when parsing single-line directives

### DIFF
--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -182,6 +182,7 @@ struct PendingBlockDirective {
             // "@xx { yy } zz }" "yy } zz" will be parsed
 
             var reversedRemainingContent = TrimmedLine(Substring(line.text.reversed()), source: line.source, lineNumber: line.lineNumber)
+            reversedRemainingContent.lexWhitespace()
             if !line.text.isEmpty,
                reversedRemainingContent.lex("}") != nil {
                 let trailingWhiteSpaceCount = reversedRemainingContent.lexWhitespace()?.text.count ?? 0

--- a/Tests/MarkdownTests/Parsing/BlockDirectiveParserTests.swift
+++ b/Tests/MarkdownTests/Parsing/BlockDirectiveParserTests.swift
@@ -982,4 +982,25 @@ class BlockDirectiveArgumentParserTests: XCTestCase {
         """#
         XCTAssertEqual(document.debugDescription(options: .printSourceLocations), expectedDump)
     }
+
+    func testSingleLineDirectiveWithTrailingWhitespace() {
+        let source = """
+        @blah { content }\(" ")
+        @blah {
+            content
+        }
+        """
+        let document = Document(parsing: source, options: [.parseBlockDirectives])
+
+        let expectedDump = #"""
+        Document @1:1-4:2
+        ├─ BlockDirective @1:1-1:19 name: "blah"
+        │  └─ Paragraph @1:9-1:17
+        │     └─ Text @1:9-1:16 "content"
+        └─ BlockDirective @2:1-4:2 name: "blah"
+           └─ Paragraph @3:5-3:12
+              └─ Text @3:5-3:12 "content"
+        """#
+        XCTAssertEqual(document.debugDescription(options: .printSourceLocations), expectedDump)
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://106458003

## Summary

When the block directive parser is checking to see if a block directive is closed on the same line that it's opened on, it checks whether the line directly ends in a closing brace. However, this means that if there is trailing whitespace on the line, the closing brace is ignored, and the directive swallows up all the content that follows it. This PR trims trailing whitespace when checking for the end of a single-line block directive.

## Dependencies

None

## Testing

```
@one { content } 
@two {
    content
}
```

(Note that this sample has a trailing space after the closing brace of the `@one` directive.)

Steps:
1. Save the above Markdown as `test.md`.
2. `swift run markdown-tool dump-tree --parse-block-directives test.md`
3. Ensure that the resulting debug tree does not place the `@two` directive inside the `@one` directive. Compare with the following tree:

```
Document
├─ BlockDirective name: "one"
│  └─ Paragraph
│     └─ Text "content"
└─ BlockDirective name: "two"
   └─ Paragraph
      └─ Text "content"
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
