### PR TITLE
track inner indentation for doxygen commands

### DIFF
--- a/Sources/Markdown/Markdown.docc/Markdown/DoxygenCommands.md
+++ b/Sources/Markdown/Markdown.docc/Markdown/DoxygenCommands.md
@@ -29,9 +29,16 @@ This is the thing that is modified.
 }
 ```
 
-Doxygen commands are not parsed within code blocks or block directive content. No indentation
-adjustment is performed on paragraph arguments that span multiple lines, unlike with block directive
-content.
+Trailing lines in a command's description are allowed to be indented relative to the command. For
+example, the description below is parsed as a paragraph, not a code block:
+
+```markdown
+\param thing
+    The thing.
+    This is the thing that is modified.
+```
+
+Doxygen commands are not parsed within code blocks or block directive content.
 
 ## Topics
 

--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -243,12 +243,18 @@ struct PendingDoxygenCommand {
 
     var nameLocation: SourceLocation
 
+    var innerIndentation: Int? = nil
+
     var kind: CommandKind
 
     var endLocation: SourceLocation
 
     mutating func addLine(_ line: TrimmedLine) {
         endLocation = SourceLocation(line: line.lineNumber ?? 0, column: line.untrimmedText.count + 1, source: line.source)
+
+        if innerIndentation == nil, line.location?.line != atLocation.line, !line.isEmptyOrAllWhitespace {
+            innerIndentation = line.indentationColumnCount
+        }
     }
 }
 
@@ -655,8 +661,8 @@ private enum ParseContainer: CustomStringConvertible {
             return parent?.indentationAdjustment(under: nil) ?? 0
         case .blockDirective(let pendingBlockDirective, _):
             return pendingBlockDirective.indentationColumnCount
-        case .doxygenCommand:
-            return parent?.indentationAdjustment(under: nil) ?? 0
+        case .doxygenCommand(let pendingCommand, _):
+            return pendingCommand.innerIndentation ?? 0
         }
     }
 

--- a/Tests/MarkdownTests/Parsing/DoxygenCommandParserTests.swift
+++ b/Tests/MarkdownTests/Parsing/DoxygenCommandParserTests.swift
@@ -127,6 +127,29 @@ class DoxygenCommandParserTests: XCTestCase {
         XCTAssertEqual(document.debugDescription(), expectedDump)
     }
 
+    func testParseWithIndentedAtSign() {
+        let source = """
+        Method description.
+
+         @param thing The thing.
+            This is the thing that is messed with.
+        """
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        let expectedDump = """
+        Document
+        ├─ Paragraph
+        │  └─ Text "Method description."
+        └─ DoxygenParameter parameter: thing
+           └─ Paragraph
+              ├─ Text "The thing."
+              ├─ SoftBreak
+              └─ Text "This is the thing that is messed with."
+        """
+        XCTAssertEqual(document.debugDescription(), expectedDump)
+    }
+
     func testBreakDescriptionWithBlankLine() {
         let source = """
         @param thing The thing.
@@ -250,6 +273,29 @@ class DoxygenCommandParserTests: XCTestCase {
               ├─ Text @1:14-1:24 "The thing."
               ├─ SoftBreak
               └─ Text @2:5-2:43 "This is the thing that is messed with."
+        """
+        XCTAssertEqual(document.debugDescription(options: .printSourceLocations), expectedDump)
+    }
+
+    func testSourceLocationsWithIndentedAtSign() {
+        let source = """
+        Method description.
+
+         @param thing The thing.
+            This is the thing that is messed with.
+        """
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        let expectedDump = """
+        Document @1:1-4:43
+        ├─ Paragraph @1:1-1:20
+        │  └─ Text @1:1-1:20 "Method description."
+        └─ DoxygenParameter @3:2-4:43 parameter: thing
+           └─ Paragraph @3:15-4:43
+              ├─ Text @3:15-3:25 "The thing."
+              ├─ SoftBreak
+              └─ Text @4:5-4:43 "This is the thing that is messed with."
         """
         XCTAssertEqual(document.debugDescription(options: .printSourceLocations), expectedDump)
     }

--- a/Tests/MarkdownTests/Parsing/DoxygenCommandParserTests.swift
+++ b/Tests/MarkdownTests/Parsing/DoxygenCommandParserTests.swift
@@ -91,6 +91,42 @@ class DoxygenCommandParserTests: XCTestCase {
         XCTAssertEqual(document.debugDescription(), expectedDump)
     }
 
+    func testParseIndentedDescription() {
+        let source = """
+        @param thing
+            The thing.
+        """
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        let expectedDump = """
+        Document
+        └─ DoxygenParameter parameter: thing
+           └─ Paragraph
+              └─ Text "The thing."
+        """
+        XCTAssertEqual(document.debugDescription(), expectedDump)
+    }
+
+    func testParseMultilineIndentedDescription() {
+        let source = """
+        @param thing The thing.
+            This is the thing that is messed with.
+        """
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        let expectedDump = """
+        Document
+        └─ DoxygenParameter parameter: thing
+           └─ Paragraph
+              ├─ Text "The thing."
+              ├─ SoftBreak
+              └─ Text "This is the thing that is messed with."
+        """
+        XCTAssertEqual(document.debugDescription(), expectedDump)
+    }
+
     func testBreakDescriptionWithBlankLine() {
         let source = """
         @param thing The thing.
@@ -188,7 +224,6 @@ class DoxygenCommandParserTests: XCTestCase {
 
         let document = Document(parsing: source, options: parseOptions)
 
-        // FIXME: The source location for the first description line is wrong
         let expectedDump = """
         Document @1:1-2:39
         └─ DoxygenParameter @1:1-2:39 parameter: thing
@@ -196,6 +231,25 @@ class DoxygenCommandParserTests: XCTestCase {
               ├─ Text @1:14-1:24 "The thing."
               ├─ SoftBreak
               └─ Text @2:1-2:39 "This is the thing that is messed with."
+        """
+        XCTAssertEqual(document.debugDescription(options: .printSourceLocations), expectedDump)
+    }
+
+    func testSourceLocationsWithIndentation() {
+        let source = """
+        @param thing The thing.
+            This is the thing that is messed with.
+        """
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        let expectedDump = """
+        Document @1:1-2:43
+        └─ DoxygenParameter @1:1-2:43 parameter: thing
+           └─ Paragraph @1:14-2:43
+              ├─ Text @1:14-1:24 "The thing."
+              ├─ SoftBreak
+              └─ Text @2:5-2:43 "This is the thing that is messed with."
         """
         XCTAssertEqual(document.debugDescription(options: .printSourceLocations), expectedDump)
     }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://107580214

## Summary

The initial implementation of Doxygen commands didn't track trailing indentation, i.e. if trailing lines of the description were indented more than the command. This PR adds that tracking, so that commands will be parsed properly if the description text is indented relative to the command name.

The tracking is done similarly to block directive indentation tracking: The first line of the description that trails past the command name sets the indentation for the rest of the description. This is then used to create the offset for parsing the description as a whole.

## Dependencies

None

## Testing

Use the following markdown:

```markdown
Method description.

@param thing
    The thing.
 @param otherThing
    The other thing.
```

Steps:
1. Save the above markdown as `test.md`.
2. `swift run markdown-tool dump-tree --parse-block-directives --experimental-parse-doxygen-commands test.md`
3. Compare the output to below:

```
Document
├─ Paragraph
│  └─ Text "Method description."
├─ DoxygenParameter parameter: thing
│  └─ Paragraph
│     └─ Text "The thing."
└─ DoxygenParameter parameter: otherThing
   └─ Paragraph
      └─ Text "The other thing."
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
