### PR TITLE
[5.9] update swift-cmark dependency to release/5.9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-cmark.git", .branch("gfm")),
+        .package(url: "https://github.com/apple/swift-cmark.git", .branch("release/5.9")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
     ]
 } else {

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -51,7 +51,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-cmark.git", .branch("gfm")),
+        .package(url: "https://github.com/apple/swift-cmark.git", .branch("release/5.9")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
     ]
     


### PR DESCRIPTION
- **Explanation**: This PR updates the package specs to point swift-cmark to `release/5.9` instead of `main`.
- **Scope**: Ensures that the 5.9 release of Swift-Markdown doesn't integrate with unintended code in swift-cmark.
- **GitHub Issue**: None
- **Risk**: None. These branches are currently identical.
- **Testing**: `bin/test` succeeds.