### PR TITLE
[5.9] track inner indentation for doxygen commands

### DIFF
--- a/Sources/Markdown/Markdown.docc/Markdown/DoxygenCommands.md
+++ b/Sources/Markdown/Markdown.docc/Markdown/DoxygenCommands.md
@@ -29,9 +29,16 @@ This is the thing that is modified.
 }
 ```
 
-Doxygen commands are not parsed within code blocks or block directive content. No indentation
-adjustment is performed on paragraph arguments that span multiple lines, unlike with block directive
-content.
+Trailing lines in a command's description are allowed to be indented relative to the command. For
+example, the description below is parsed as a paragraph, not a code block:
+
+```markdown
+\param thing
+    The thing.
+    This is the thing that is modified.
+```
+
+Doxygen commands are not parsed within code blocks or block directive content.
 
 ## Topics
 

--- a/Tests/MarkdownTests/Parsing/DoxygenCommandParserTests.swift
+++ b/Tests/MarkdownTests/Parsing/DoxygenCommandParserTests.swift
@@ -91,6 +91,65 @@ class DoxygenCommandParserTests: XCTestCase {
         XCTAssertEqual(document.debugDescription(), expectedDump)
     }
 
+    func testParseIndentedDescription() {
+        let source = """
+        @param thing
+            The thing.
+        """
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        let expectedDump = """
+        Document
+        └─ DoxygenParameter parameter: thing
+           └─ Paragraph
+              └─ Text "The thing."
+        """
+        XCTAssertEqual(document.debugDescription(), expectedDump)
+    }
+
+    func testParseMultilineIndentedDescription() {
+        let source = """
+        @param thing The thing.
+            This is the thing that is messed with.
+        """
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        let expectedDump = """
+        Document
+        └─ DoxygenParameter parameter: thing
+           └─ Paragraph
+              ├─ Text "The thing."
+              ├─ SoftBreak
+              └─ Text "This is the thing that is messed with."
+        """
+        XCTAssertEqual(document.debugDescription(), expectedDump)
+    }
+
+    func testParseWithIndentedAtSign() {
+        let source = """
+        Method description.
+
+         @param thing The thing.
+            This is the thing that is messed with.
+        """
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        let expectedDump = """
+        Document
+        ├─ Paragraph
+        │  └─ Text "Method description."
+        └─ DoxygenParameter parameter: thing
+           └─ Paragraph
+              ├─ Text "The thing."
+              ├─ SoftBreak
+              └─ Text "This is the thing that is messed with."
+        """
+        XCTAssertEqual(document.debugDescription(), expectedDump)
+    }
+
     func testBreakDescriptionWithBlankLine() {
         let source = """
         @param thing The thing.
@@ -188,7 +247,6 @@ class DoxygenCommandParserTests: XCTestCase {
 
         let document = Document(parsing: source, options: parseOptions)
 
-        // FIXME: The source location for the first description line is wrong
         let expectedDump = """
         Document @1:1-2:39
         └─ DoxygenParameter @1:1-2:39 parameter: thing
@@ -196,6 +254,48 @@ class DoxygenCommandParserTests: XCTestCase {
               ├─ Text @1:14-1:24 "The thing."
               ├─ SoftBreak
               └─ Text @2:1-2:39 "This is the thing that is messed with."
+        """
+        XCTAssertEqual(document.debugDescription(options: .printSourceLocations), expectedDump)
+    }
+
+    func testSourceLocationsWithIndentation() {
+        let source = """
+        @param thing The thing.
+            This is the thing that is messed with.
+        """
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        let expectedDump = """
+        Document @1:1-2:43
+        └─ DoxygenParameter @1:1-2:43 parameter: thing
+           └─ Paragraph @1:14-2:43
+              ├─ Text @1:14-1:24 "The thing."
+              ├─ SoftBreak
+              └─ Text @2:5-2:43 "This is the thing that is messed with."
+        """
+        XCTAssertEqual(document.debugDescription(options: .printSourceLocations), expectedDump)
+    }
+
+    func testSourceLocationsWithIndentedAtSign() {
+        let source = """
+        Method description.
+
+         @param thing The thing.
+            This is the thing that is messed with.
+        """
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        let expectedDump = """
+        Document @1:1-4:43
+        ├─ Paragraph @1:1-1:20
+        │  └─ Text @1:1-1:20 "Method description."
+        └─ DoxygenParameter @3:2-4:43 parameter: thing
+           └─ Paragraph @3:15-4:43
+              ├─ Text @3:15-3:25 "The thing."
+              ├─ SoftBreak
+              └─ Text @4:5-4:43 "This is the thing that is messed with."
         """
         XCTAssertEqual(document.debugDescription(options: .printSourceLocations), expectedDump)
     }


### PR DESCRIPTION
Cherry-pick of #118

- **Explanation**: Doxygen commands that start with indentation, or whose trailing description lines are indented from the command line, are not properly parsed. This PR changes the parsing strategy to handle indentation in these cases.
- **Scope**: Allows the new Doxygen parsing feature to be used with more inputs.
- **Issue**: rdar://107580214
- **Risk**: Low. This should only affect the Doxygen command parsing. Everything else should be unaffected.
- **Testing**: Tests were added to ensure that Doxygen commands with indentation on either the command line or in trailing description lines are correctly parsed.
- **Reviewer**: @ethan-kusters 