### PR TITLE
Fix crash parsing document tree dump as markdown content

### DIFF
--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -190,9 +190,7 @@ struct PendingBlockDirective {
                 let leadingSpacingCount = line.untrimmedText.count - textCount - trailingWhiteSpaceCount - 1
                 innerIndentationColumnCount = leadingSpacingCount // Should we add a new property for this kind of usage?
                 
-                let startIndex = line.untrimmedText.startIndex
-                let endIndex = line.untrimmedText.index(startIndex, offsetBy: leadingSpacingCount)
-                let newLine = line.untrimmedText.replacingCharacters(in: startIndex..<endIndex, with: String(repeating: " ", count: leadingSpacingCount)).dropLast(trailingWhiteSpaceCount + 1)
+                let newLine = String(repeating: " ", count: leadingSpacingCount) + line.untrimmedText.dropFirst(leadingSpacingCount).dropLast(trailingWhiteSpaceCount + 1)
                 pendingLine = TrimmedLine(newLine.dropFirst(0), source: line.source, lineNumber: line.lineNumber)
                 parseState = .done
                 endLocation = SourceLocation(line: line.lineNumber ?? 0, column: line.untrimmedText.count + 1, source: line.source)

--- a/Tests/MarkdownTests/Parsing/BlockDirectiveParserTests.swift
+++ b/Tests/MarkdownTests/Parsing/BlockDirectiveParserTests.swift
@@ -1020,4 +1020,27 @@ class BlockDirectiveArgumentParserTests: XCTestCase {
         """#
         XCTAssertEqual(document.debugDescription(options: .printSourceLocations), expectedDump)
     }
+    
+    func testParsingTreeDumpFollowedByDirective() {
+        let source = """
+        Document
+        ├─ Heading level: 1
+        │  └─ Text "Title"
+        @Comment { Line c This is a single-line comment }
+        """
+        let documentation = Document(parsing: source, options: .parseBlockDirectives)
+        let expected = """
+        Document
+        ├─ Paragraph
+        │  ├─ Text "Document"
+        │  ├─ SoftBreak
+        │  ├─ Text "├─ Heading level: 1"
+        │  ├─ SoftBreak
+        │  └─ Text "│  └─ Text “Title”"
+        └─ BlockDirective name: "Comment"
+           └─ Paragraph
+              └─ Text "Line c This is a single-line comment"
+        """
+        XCTAssertEqual(expected, documentation.debugDescription())
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://108281578

## Summary

Fix a crash (String index range is out of bounds) when parsing a document tree dump followed by a one-line directive as markdown content. See test

## Dependencies

None.

## Testing

See the added test.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
