### PR TITLE
set up release/5.9-05012023

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-cmark.git", .branch("release/5.9")),
+        .package(url: "https://github.com/apple/swift-cmark.git", .branch("release/5.9-05012023")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
     ]
 } else {

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -51,7 +51,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-cmark.git", .branch("release/5.9")),
+        .package(url: "https://github.com/apple/swift-cmark.git", .branch("release/5.9-05012023")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
     ]
     


### PR DESCRIPTION
Bug/issue #, if applicable: None

## Summary

This PR sets up the package dependency on swift-cmark to correctly point to the new `release/5.9-05012023` branch.