### PR TITLE
Refactored the `lex` function in the BlockDirectiveParser file

### DIFF
--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -414,9 +414,7 @@ struct TrimmedLine {
                 isEscaped = true
             }
             else if isQuoted {
-                if c == "\"" {
-                    isQuoted = false
-                }
+                isQuoted = (c != "\"")
             }
             else if allowQuote,
                c == "\"" {

--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -408,29 +408,21 @@ struct TrimmedLine {
         while let c = prefix.next() {
             if isEscaped {
                 isEscaped = false
-                takeCount += 1
-                continue
             }
-            if allowEscape,
+            else if allowEscape,
                c == "\\" {
                 isEscaped = true
-                takeCount += 1
-                continue
             }
-            if isQuoted {
+            else if isQuoted {
                 if c == "\"" {
                     isQuoted = false
                 }
-                takeCount += 1
-                continue
             }
-            if allowQuote,
+            else if allowQuote,
                c == "\"" {
                 isQuoted = true
-                takeCount += 1
-                continue
             }
-            if case .stop = stop(c) {
+            else if case .stop = stop(c) {
                 break
             }
             takeCount += 1


### PR DESCRIPTION
## Summary
- This PR refactors the current implementation of `lex` function of the `TrimmedLine`. It's intended to make the code more readable and concise without breaking the existing intended functionality.
- In the New implementation, instead of incrementing the `takeCount` var (within while loop) at every certain conditions. We can increment the variable at the end directly.
- This makes the code concise and hence easier to read and debug the while loop.

## Dependencies

_Describe any dependencies this PR might have, such as an associated branch in another repository._

## Testing

I believe this is a minor refactoring of increment of `takeCount` and doesn't require any new tests.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
