### PR TITLE
 Refactored the `lex` function in the BlockDirectiveParser file.

### DIFF
--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -414,9 +414,7 @@ struct TrimmedLine {
                 isEscaped = true
             }
             else if isQuoted {
-                if c == "\"" {
-                    isQuoted = false
-                }
+                isQuoted = (c != "\"")
             }
             else if allowQuote,
                c == "\"" {

--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -408,29 +408,21 @@ struct TrimmedLine {
         while let c = prefix.next() {
             if isEscaped {
                 isEscaped = false
-                takeCount += 1
-                continue
             }
-            if allowEscape,
+            else if allowEscape,
                c == "\\" {
                 isEscaped = true
-                takeCount += 1
-                continue
             }
-            if isQuoted {
+            else if isQuoted {
                 if c == "\"" {
                     isQuoted = false
                 }
-                takeCount += 1
-                continue
             }
-            if allowQuote,
+            else if allowQuote,
                c == "\"" {
                 isQuoted = true
-                takeCount += 1
-                continue
             }
-            if case .stop = stop(c) {
+            else if case .stop = stop(c) {
                 break
             }
             takeCount += 1


### PR DESCRIPTION
## Summary

- This PR refactors the current implementation of `lex` function of the `TrimmedLine`. It's intended to make the code more readable and concise without breaking the existing intended functionality.
- In the updated implementation, instead of incrementing the `takeCount` var (within while loop) at every certain conditions, it will update the takeCount only once at the end. 
- Also, instead of checking for `if` condition to populate the `isQuoted` var, we can directly use the boolean result of `!=` relational operator to populate the variable.
- This makes the code concise and more easier to debug and dry-run the while loop.

## Testing

I believe this is a minor refactoring and doesn't require any new tests. All the existing test cases was passing. 💯 

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary

## Note
- This is my first ever contribution to this repository. I made sure that I read the contributing guidelines.
- Still if there's anything I can improve, please give your feedback, would love to work on that. 👨‍💻 


