### PR TITLE
Footnotes

### DIFF
--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -51,7 +51,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-cmark.git", .branch("gfm")),
+        .package(url: "https://github.com/apple/swift-cmark.git", .branch("QuietMisdreavus/footnote-fixes")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
     ]
     

--- a/Sources/Markdown/Base/Markup.swift
+++ b/Sources/Markdown/Base/Markup.swift
@@ -75,6 +75,10 @@ func makeMarkup(_ data: _MarkupData) -> Markup {
         return DoxygenParameter(data)
     case .doxygenReturns:
         return DoxygenReturns(data)
+    case .footnoteReference:
+        return FootnoteReference(data)
+    case .footnoteDefinition:
+        return FootnoteDefinition(data)
     }
 }
 

--- a/Sources/Markdown/Base/RawMarkup.swift
+++ b/Sources/Markdown/Base/RawMarkup.swift
@@ -54,6 +54,8 @@ enum RawMarkupData: Equatable {
 
     case doxygenParam(name: String)
     case doxygenReturns
+    case footnoteReference(footnoteID: String)
+    case footnoteDefinition(footnoteID: String)
 }
 
 extension RawMarkupData {
@@ -247,6 +249,10 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
     static func blockDirective(name: String, nameLocation: SourceLocation?, argumentText: DirectiveArgumentText, parsedRange: SourceRange?, _ children: [RawMarkup]) -> RawMarkup {
         return .create(data: .blockDirective(name: name, nameLocation: nameLocation, arguments: argumentText), parsedRange: parsedRange, children: children)
     }
+    
+    static func footnoteDefinition(footnoteID: String, parsedRange: SourceRange?, _ children: [RawMarkup]) -> RawMarkup {
+        return .create(data: .footnoteDefinition(footnoteID: footnoteID), parsedRange: parsedRange, children: children)
+    }
 
     // MARK: Inline Creation
 
@@ -297,6 +303,11 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
     static func inlineAttributes(attributes: String, parsedRange: SourceRange?, _ children: [RawMarkup]) -> RawMarkup {
         return .create(data: .inlineAttributes(attributes: attributes), parsedRange: parsedRange, children: children)
     }
+    
+    static func footnoteReference(footnoteID: String, parsedRange: SourceRange?, _ children: [RawMarkup]) -> RawMarkup {
+        return .create(data: .footnoteReference(footnoteID: footnoteID), parsedRange: parsedRange, children: children)
+    }
+    
 
     // MARK: Extensions
 

--- a/Sources/Markdown/Base/RawMarkup.swift
+++ b/Sources/Markdown/Base/RawMarkup.swift
@@ -251,6 +251,7 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
     }
     
     static func footnoteDefinition(footnoteID: String, parsedRange: SourceRange?, _ children: [RawMarkup]) -> RawMarkup {
+        
         return .create(data: .footnoteDefinition(footnoteID: footnoteID), parsedRange: parsedRange, children: children)
     }
 

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/FootnoteDefinition.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/FootnoteDefinition.swift
@@ -1,3 +1,13 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
 public struct FootnoteDefinition: BlockContainer {
     public var _data: _MarkupData
     init(_ raw: RawMarkup) throws {

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/FootnoteDefinition.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/FootnoteDefinition.swift
@@ -22,6 +22,10 @@ public extension FootnoteDefinition {
         try! self.init(.footnoteDefinition(footnoteID: footnoteID, parsedRange: nil, children.map { $0.raw.markup }))
     }
     
+    init(footnoteID: String, _ children: BlockMarkup...) {
+        self.init(footnoteID: footnoteID, children)
+    }
+    
     var footnoteID: String {
         get {
             guard case let .footnoteDefinition(footnoteID: footnoteID) = _data.raw.markup.data else {

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/FootnoteDefinition.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/FootnoteDefinition.swift
@@ -1,0 +1,42 @@
+public struct FootnoteDefinition: BlockContainer {
+    public var _data: _MarkupData
+    init(_ raw: RawMarkup) throws {
+        guard case .footnoteDefinition = raw.data else {
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: FootnoteDefinition.self)
+        }
+        let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
+        self.init(_MarkupData(absoluteRaw))
+    }
+
+    init(_ data: _MarkupData) {
+        self._data = data
+    }
+}
+
+// MARK: - Public API
+
+public extension FootnoteDefinition {
+    // MARK: BasicBlockContainer
+
+    init<Children: Sequence>(footnoteID: String, _ children: Children) where Children.Element == BlockMarkup {
+        try! self.init(.footnoteDefinition(footnoteID: footnoteID, parsedRange: nil, children.map { $0.raw.markup }))
+    }
+    
+    var footnoteID: String {
+        get {
+            guard case let .footnoteDefinition(footnoteID: footnoteID) = _data.raw.markup.data else {
+                fatalError("\(self) markup wrapped unexpected \(_data.raw)")
+            }
+            return footnoteID
+        }
+        set {
+            _data = _data.replacingSelf(.footnoteDefinition(footnoteID: newValue, parsedRange: nil, _data.raw.markup.copyChildren()))
+        }
+    }
+
+    // MARK: Visitation
+
+    func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
+        return visitor.visitFootnoteDefinition(self)
+    }
+}

--- a/Sources/Markdown/Inline Nodes/Inline Containers/FootnoteReference.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/FootnoteReference.swift
@@ -1,0 +1,57 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// A reference to a footnote
+public struct FootnoteReference: InlineMarkup, InlineContainer {
+    public var _data: _MarkupData
+
+    init(_ raw: RawMarkup) throws {
+        guard case .footnoteReference = raw.data else {
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: FootnoteReference.self)
+        }
+        let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
+        self.init(_MarkupData(absoluteRaw))
+    }
+
+    init(_ data: _MarkupData) {
+        self._data = data
+    }
+}
+
+// MARK: - Public API
+
+public extension FootnoteReference {
+    init<Children: Sequence>(footnoteID: String, _ children: Children) where Children.Element == RecurringInlineMarkup {
+        try! self.init(.footnoteReference(footnoteID: footnoteID, parsedRange: nil, children.map { $0.raw.markup }))
+    }
+
+    init(footnoteID: String, _ children: RecurringInlineMarkup...) {
+        self.init(footnoteID: footnoteID, children)
+    }
+    
+    /// The specified attributes in JSON5 format.
+    var footnoteID: String {
+        get {
+            guard case let .footnoteReference(footnoteID: footnoteID) = _data.raw.markup.data else {
+                fatalError("\(self) markup wrapped unexpected \(_data.raw)")
+            }
+            return footnoteID
+        }
+        set {
+            _data = _data.replacingSelf(.footnoteReference(footnoteID: newValue, parsedRange: nil, _data.raw.markup.copyChildren()))
+        }
+    }
+    
+    // MARK: Visitation
+
+    func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
+        return visitor.visitFootnoteReference(self)
+    }
+}

--- a/Sources/Markdown/Rewriter/MarkupRewriter.swift
+++ b/Sources/Markdown/Rewriter/MarkupRewriter.swift
@@ -87,4 +87,11 @@ extension MarkupRewriter {
     public mutating func visitText(_ text: Text) -> Result {
         return defaultVisit(text)
     }
+    public mutating func visitFootnoteReference(_ footnoteReference: FootnoteReference) -> Result {
+        return defaultVisit(footnoteReference)
+    }
+    
+    public mutating func visitFootnoteDefinition(_ footnoteDefinition: FootnoteDefinition) -> Result {
+        return defaultVisit(footnoteDefinition)
+    }
 }

--- a/Sources/Markdown/Visitor/MarkupVisitor.swift
+++ b/Sources/Markdown/Visitor/MarkupVisitor.swift
@@ -274,6 +274,10 @@ public protocol MarkupVisitor {
     - returns: The result of the visit.
      */
      mutating func visitInlineAttributes(_ attributes: InlineAttributes) -> Result
+    
+    mutating func visitFootnoteReference(_ footnoteReference: FootnoteReference) -> Result
+    
+    mutating func visitFootnoteDefinition(_ footnoteDefinition: FootnoteDefinition) -> Result
 
     /**
      Visit a `DoxygenParam` element and return the result.
@@ -394,5 +398,12 @@ extension MarkupVisitor {
     }
     public mutating func visitDoxygenReturns(_ doxygenReturns: DoxygenReturns) -> Result {
         return defaultVisit(doxygenReturns)
+    }
+    
+    public mutating func visitFootnoteReference(_ footnoteReference: FootnoteReference) -> Result {
+        return defaultVisit(footnoteReference)
+    }
+    public mutating func visitFootnoteDefinition(_ footnoteDefinition: FootnoteDefinition) -> Result {
+        return defaultVisit(footnoteDefinition)
     }
 }

--- a/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
@@ -295,7 +295,7 @@ struct MarkupTreeDumper: MarkupWalker {
         dump(footnoteReference, customDescription: "footnoteID: `\(footnoteReference.footnoteID)`")
     }
     
-    mutating func visitFootnoteReference(_ footnoteDefinition: FootnoteDefinition) -> () {
+    mutating func visitFootnoteDefinition(_ footnoteDefinition: FootnoteDefinition) -> () {
         dump(footnoteDefinition, customDescription: "footnoteID: `\(footnoteDefinition.footnoteID)`")
     }
 

--- a/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
@@ -290,4 +290,13 @@ struct MarkupTreeDumper: MarkupWalker {
     mutating func visitDoxygenParameter(_ doxygenParam: DoxygenParameter) -> () {
         dump(doxygenParam, customDescription: "parameter: \(doxygenParam.name)")
     }
+    
+    mutating func visitFootnoteReference(_ footnoteReference: FootnoteReference) -> () {
+        dump(footnoteReference, customDescription: "footnoteID: `\(footnoteReference.footnoteID)`")
+    }
+    
+    mutating func visitFootnoteReference(_ footnoteDefinition: FootnoteDefinition) -> () {
+        dump(footnoteDefinition, customDescription: "footnoteID: `\(footnoteDefinition.footnoteID)`")
+    }
+
 }

--- a/Sources/markdown-tool/main.swift
+++ b/Sources/markdown-tool/main.swift
@@ -30,6 +30,8 @@ struct MarkdownCommand: ParsableCommand {
     ])
 
     static func parseFile(at path: String, options: ParseOptions) throws -> (source: String, parsed: Document) {
+        print(path)
+        print(Process().currentDirectoryPath)
         let data = try Data(contentsOf: URL(fileURLWithPath: path))
         guard let inputString = String(data: data, encoding: .utf8) else {
             throw Error.couldntDecodeInputAsUTF8

--- a/Tests/MarkdownTests/Parsing/FootnoteTest.swift
+++ b/Tests/MarkdownTests/Parsing/FootnoteTest.swift
@@ -1,0 +1,36 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+@testable import Markdown
+import XCTest
+
+class FootnoteTests: XCTestCase {
+    func testFootnotes() {
+        let text = """
+        text with a footnote [^1].
+
+        [^1]: footnote definition.
+        """
+
+        let expectedDump = """
+        Document @1:1-3:27
+        ├─ Paragraph @1:1-1:27
+        │  ├─ Text @1:1-1:22 "text with a footnote "
+        │  ├─ FootnoteReference @1:22-1:26 footnoteID: `1`
+        │  └─ Text @1:26-1:27 "."
+        └─ FootnoteDefinition @3:7-3:27 footnoteID: `1`
+           └─ Paragraph @3:7-3:27
+              └─ Text @3:7-3:27 "footnote definition."
+        """
+
+        let document = Document(parsing: text, source: nil, options: [.parseBlockDirectives, .parseSymbolLinks])
+        XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
+    }
+}


### PR DESCRIPTION
## Summary

Added footnote parsing functionality. Consists of two parts: Footnote Reference and Footnote Definition

## Dependencies

It is dependend on this version of swift-cmark: https://github.com/apple/swift-cmark/pull/57

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [n/a ] Updated documentation if necessary
