### PR TITLE
fix: fix to issue #132 (implementation of child(through)

### DIFF
--- a/Sources/Markdown/Base/Markup.swift
+++ b/Sources/Markdown/Base/Markup.swift
@@ -265,7 +265,7 @@ extension Markup {
     public func child(through path: TypedChildIndexPath) -> Markup? {
         var element: Markup = self
         for pathElement in path {
-            guard pathElement.index <= raw.markup.childCount else {
+            guard pathElement.index <= element.childCount else {
                 return nil
             }
 

--- a/Tests/MarkdownTests/Base/MarkupTests.swift
+++ b/Tests/MarkdownTests/Base/MarkupTests.swift
@@ -283,6 +283,21 @@ final class MarkupTests: XCTestCase {
             )!.debugDescription()
         )
     }
+
+    func testChildThroughIndicesWithMultipleParagraphs() {
+        let source = """
+This is a markup __*document*__ with *some* **more** attributes.
+
+This is the *second* paragraph.
+This is on a **new** line, but, continues on the same paragraph.
+
+This is the *third* paragraph.
+This is on a **new** line, but, continues on the same paragraph.
+"""
+
+        let document = Document(parsing: source)
+        XCTAssertNotNil(document.child(through: [2, 5]) as? Strong)
+    }
     
     func testChildAtPositionHasCorrectType() throws {
         let source = "This is a [*link*](github.com). And some **bold** and *italic* text."


### PR DESCRIPTION
`func child(through path: TypedChildIndexPath) -> Markup?` uses the root document node's child count for comparison against the passed in path for valid reference to a child. Changed it to use the current iterated element.

fix #132

Bug/issue #, if applicable: 

## Summary

_Provide a description of what your PR addresses, explaining the expected user experience. 
Also, provide an overview of your implementation._

## Dependencies

_Describe any dependencies this PR might have, such as an associated branch in another repository._

## Testing

_Describe how a reviewer can test the functionality of your PR. Provide test content to test with if
applicable._

Steps:
1. _Provide setup instructions._
2. _Explain in detail how the functionality can be tested._

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
