### PR TITLE
Add primary associated type for MarkupVisitor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 /*
  This source file is part of the Swift.org open source project
 

--- a/Sources/Markdown/Visitor/MarkupVisitor.swift
+++ b/Sources/Markdown/Visitor/MarkupVisitor.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,7 +13,7 @@
 /// - note: This interface only provides requirements for visiting each kind of element. It does not require each visit method to descend into child elements.
 ///
 /// Generally, ``MarkupWalker`` is best for walking a ``Markup`` tree if the ``Result`` type is `Void` or is built up some other way, or ``MarkupRewriter`` for recursively changing a tree's structure. This type serves as a common interface to both. However, for building up other structured result types you can implement ``MarkupVisitor`` directly.
-public protocol MarkupVisitor {
+public protocol MarkupVisitor<Result> {
 
     /**
      The result type returned when visiting a element.

--- a/Tests/MarkdownTests/Visitors/MarkupVisitorTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupVisitorTests.swift
@@ -1,0 +1,26 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import Markdown
+
+class MarkupVisitorTests: XCTestCase {
+    struct EmptyWalker: MarkupWalker {
+        mutating func defaultVisit(_ markup: Markdown.Markup) -> Void {
+            return
+        }
+    }
+    
+    // A compile time check for PAT support
+    func testMarkupVisitorPrimaryAssociatedType() {
+        var vistor: some MarkupVisitor<Void> = EmptyWalker()
+        vistor.visit(Text(""))
+    }
+}


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

Add primary associated type for `MarkupVisitor`

Update: Bump the minimal supported Swift version to Swift 5.7

## Alternatives

~The current implementation of PAT support for `MarkupVisitor` has a lot of duplicated code since PAT was introduced by Swift 5.7.~

~We could drop such duplication if we can update this Package's min supported Swift version to Swift 5.7.~

See #78

## Testing

See `MarkupVisitorTests.swift`

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
