### PR TITLE
build: add a CMake based build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,61 @@
+#[[
+This source file is part of the Swift System open source project
+
+Copyright (c) 2024 Apple Inc. and the Swift System project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+cmake_minimum_required(VERSION 3.19.0)
+
+if(POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif()
+
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+endif()
+
+project(SwiftMarkdown
+  LANGUAGES C Swift)
+
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
+set(CMAKE_Swift_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
+
+include(FetchContent)
+include(SwiftSupport)
+
+set(_SM_VENDOR_DEPENDENCIES)
+
+set(BUILD_EXAMPLES NO)
+set(BUILD_TESTING NO)
+
+find_package(ArgumentParser CONFIG)
+if(NOT ArgumentParser_FOUND)
+  FetchContent_Declare(ArgumentParser
+    GIT_REPOSITORY https://github.com/apple/swift-argument-parser
+    GIT_TAG 1.2.3)
+  list(APPEND _SM_VENDOR_DEPENDENCIES ArgumentParser)
+endif()
+
+find_package(cmark-gfm CONFIG)
+if(NOT cmark-gfm_FOUND)
+  FetchContent_Declare(cmark-gfm
+    GIT_REPOSITORY https://github.com/apple/swift-cmark
+    GIT_TAG gfm)
+  list(APPEND _SM_VENDOR_DEPENDENCIES cmark-gfm)
+endif()
+
+if(_SM_VENDOR_DEPENDENCIES)
+  FetchContent_MakeAvailable(${_SM_VENDOR_DEPENDENCIES})
+endif()
+
+add_subdirectory(Sources)
+add_subdirectory(cmake/modules)

--- a/Sources/CAtomic/CMakeLists.txt
+++ b/Sources/CAtomic/CMakeLists.txt
@@ -1,0 +1,15 @@
+#[[
+This source file is part of the Swift System open source project
+
+Copyright (c) 2024 Apple Inc. and the Swift System project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+add_library(CAtomic STATIC
+  CAtomic.c)
+target_include_directories(CAtomic PUBLIC
+  include)
+
+set_property(GLOBAL APPEND PROPERTY SWIFT_MARKDOWN_EXPORTS CAtomic)

--- a/Sources/CAtomic/include/module.modulemap
+++ b/Sources/CAtomic/include/module.modulemap
@@ -1,0 +1,4 @@
+module CAtomic {
+  header "CAtomic.h"
+  export *
+}

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,0 +1,11 @@
+#[[
+This source file is part of the Swift System open source project
+
+Copyright (c) 2024 Apple Inc. and the Swift System project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+add_subdirectory(CAtomic)
+add_subdirectory(Markdown)

--- a/Sources/Markdown/CMakeLists.txt
+++ b/Sources/Markdown/CMakeLists.txt
@@ -1,0 +1,87 @@
+#[[
+This source file is part of the Swift System open source project
+
+Copyright (c) 2024 Apple Inc. and the Swift System project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+add_library(Markdown
+  Base/ChildIndexPath.swift
+  Base/DirectiveArgument.swift
+  Base/Document.swift
+  Base/LiteralMarkup.swift
+  Base/Markup.swift
+  Base/MarkupChildren.swift
+  Base/MarkupData.swift
+  Base/PlainTextConvertibleMarkup.swift
+  Base/RawMarkup.swift
+  "Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenParameter.swift"
+  "Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenReturns.swift"
+  "Block Nodes/Block Container Blocks/BlockDirective.swift"
+  "Block Nodes/Block Container Blocks/BlockQuote.swift"
+  "Block Nodes/Block Container Blocks/CustomBlock.swift"
+  "Block Nodes/Block Container Blocks/ListItem.swift"
+  "Block Nodes/Block Container Blocks/OrderedList.swift"
+  "Block Nodes/Block Container Blocks/UnorderedList.swift"
+  "Block Nodes/Inline Container Blocks/Paragraph.swift"
+  "Block Nodes/Leaf Blocks/CodeBlock.swift"
+  "Block Nodes/Leaf Blocks/Heading.swift"
+  "Block Nodes/Leaf Blocks/HTMLBlock.swift"
+  "Block Nodes/Leaf Blocks/ThematicBreak.swift"
+  "Block Nodes/Tables/Table.swift"
+  "Block Nodes/Tables/TableBody.swift"
+  "Block Nodes/Tables/TableCell.swift"
+  "Block Nodes/Tables/TableCellContainer.swift"
+  "Block Nodes/Tables/TableHead.swift"
+  "Block Nodes/Tables/TableRow.swift"
+  Infrastructure/Replacement.swift
+  Infrastructure/SourceLocation.swift
+  "Inline Nodes/Inline Containers/Emphasis.swift"
+  "Inline Nodes/Inline Containers/Image.swift"
+  "Inline Nodes/Inline Containers/InlineAttributes.swift"
+  "Inline Nodes/Inline Containers/Link.swift"
+  "Inline Nodes/Inline Containers/Strikethrough.swift"
+  "Inline Nodes/Inline Containers/Strong.swift"
+  "Inline Nodes/Inline Leaves/CustomInline.swift"
+  "Inline Nodes/Inline Leaves/InlineCode.swift"
+  "Inline Nodes/Inline Leaves/InlineHTML.swift"
+  "Inline Nodes/Inline Leaves/LineBreak.swift"
+  "Inline Nodes/Inline Leaves/SoftBreak.swift"
+  "Inline Nodes/Inline Leaves/SymbolLink.swift"
+  "Inline Nodes/Inline Leaves/Text.swift"
+  "Interpretive Nodes/Aside.swift"
+  Parser/BlockDirectiveParser.swift
+  Parser/CommonMarkConverter.swift
+  Parser/LazySplitLines.swift
+  Parser/ParseOptions.swift
+  Parser/RangeAdjuster.swift
+  Parser/RangerTracker.swift
+  Rewriter/MarkupRewriter.swift
+  "Structural Restrictions/BasicBlockContainer.swift"
+  "Structural Restrictions/BasicInlineContainer.swift"
+  "Structural Restrictions/BlockContainer.swift"
+  "Structural Restrictions/BlockMarkup.swift"
+  "Structural Restrictions/InlineContainer.swift"
+  "Structural Restrictions/InlineMarkup.swift"
+  "Structural Restrictions/ListItemContainer.swift"
+  Utility/AtomicCounter.swift
+  Utility/CharacterExtensions.swift
+  Utility/CollectionExtensions.swift
+  Utility/StringExtensions.swift
+  Visitor/MarkupVisitor.swift
+  Walker/MarkupWalker.swift
+  Walker/Walkers/MarkupFormatter.swift
+  Walker/Walkers/MarkupTreeDumper.swift)
+target_link_libraries(Markdown PRIVATE
+  ArgumentParser
+  libcmark-gfm
+  libcmark-gfm-extensions)
+target_link_libraries(Markdown PUBLIC
+  CAtomic)
+set_target_properties(Markdown PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+_install_target(Markdown)
+set_property(GLOBAL APPEND PROPERTY SWIFT_MARKDOWN_EXPORTS Markdown)

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,0 +1,20 @@
+#[[
+This source file is part of the Swift System open source project
+
+Copyright (c) 2024 Apple Inc. and the Swift System project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+set(SWIFT_MARKDOWN_EXPORTS_FILE
+  ${CMAKE_CURRENT_BINARY_DIR}/SwiftMarkdownExports.cmake)
+
+configure_file(SwiftMarkdownConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/SwiftMarkdownConfig.cmake)
+
+get_property(SWIFT_MARKDOWN_EXPORTS GLOBAL PROPERTY SWIFT_MARKDOWN_EXPORTS)
+export(TARGETS ${SWIFT_MARKDOWN_EXPORTS}
+  NAMESPACE SwiftMarkdown::
+  FILE ${SWIFT_MARKDOWN_EXPORTS_FILE}
+  EXPORT_LINK_INTERFACE_LIBRARIES)

--- a/cmake/modules/SwiftMarkdownConfig.cmake.in
+++ b/cmake/modules/SwiftMarkdownConfig.cmake.in
@@ -1,0 +1,12 @@
+#[[
+This source file is part of the Swift System open source project
+
+Copyright (c) 2024 Apple Inc. and the Swift System project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+if(NOT TARGET SwiftMarkdown)
+  include("@SWIFT_MARKDOWN_EXPORTS_FILE@")
+endif()

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -1,0 +1,105 @@
+#[[
+This source file is part of the Swift System open source project
+
+Copyright (c) 2024 Apple Inc. and the Swift System project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+# Returns the current architecture name in a variable
+#
+# Usage:
+#   get_swift_host_arch(result_var_name)
+#
+# If the current architecture is supported by Swift, sets ${result_var_name}
+# with the sanitized host architecture name derived from CMAKE_SYSTEM_PROCESSOR.
+function(get_swift_host_arch result_var_name)
+  if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+    set("${result_var_name}" "x86_64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
+    set("${result_var_name}" "aarch64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64")
+    set("${result_var_name}" "powerpc64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le")
+    set("${result_var_name}" "powerpc64le" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "s390x")
+    set("${result_var_name}" "s390x" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv6l")
+    set("${result_var_name}" "armv6" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7l")
+    set("${result_var_name}" "armv7" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7-a")
+    set("${result_var_name}" "armv7" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "amd64")
+    set("${result_var_name}" "amd64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "AMD64")
+    set("${result_var_name}" "x86_64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "IA64")
+    set("${result_var_name}" "itanium" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86")
+    set("${result_var_name}" "i686" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "i686")
+    set("${result_var_name}" "i686" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "wasm32")
+    set("${result_var_name}" "wasm32" PARENT_SCOPE)
+  else()
+    message(FATAL_ERROR "Unrecognized architecture on host system: ${CMAKE_SYSTEM_PROCESSOR}")
+  endif()
+endfunction()
+
+# Returns the os name in a variable
+#
+# Usage:
+#   get_swift_host_os(result_var_name)
+#
+#
+# Sets ${result_var_name} with the converted OS name derived from
+# CMAKE_SYSTEM_NAME.
+function(get_swift_host_os result_var_name)
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    set(${result_var_name} macosx PARENT_SCOPE)
+  else()
+    string(TOLOWER ${CMAKE_SYSTEM_NAME} cmake_system_name_lc)
+    set(${result_var_name} ${cmake_system_name_lc} PARENT_SCOPE)
+  endif()
+endfunction()
+
+function(_install_target module)
+  get_swift_host_os(swift_os)
+  get_target_property(type ${module} TYPE)
+
+  if(type STREQUAL STATIC_LIBRARY)
+    set(swift swift_static)
+  else()
+    set(swift swift)
+  endif()
+
+  install(TARGETS ${module}
+    ARCHIVE DESTINATION lib/${swift}/${swift_os}
+    LIBRARY DESTINATION lib/${swift}/${swift_os}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+  if(type STREQUAL EXECUTABLE)
+    return()
+  endif()
+
+  get_swift_host_arch(swift_arch)
+  get_target_property(module_name ${module} Swift_MODULE_NAME)
+  if(NOT module_name)
+    set(module_name ${module})
+  endif()
+
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
+      DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
+      RENAME ${swift_arch}.swiftdoc)
+    install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
+      DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
+      RENAME ${swift_arch}.swiftmodule)
+  else()
+    install(FILES
+      $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
+      $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
+      DESTINATION lib/${swift}/${swift_os}/${swift_arch})
+  endif()
+endfunction()


### PR DESCRIPTION
This is meant to support building swift-markdown for re-use in the toolchain build.  It does not follow best practices (opting for a single file approach rather than a CMakeLists.txt per directory) and currently needs some refinement for integrating an existing CMark build, but provides the skeleton for further experimentation.