### PR TITLE
Fix multi line symbol link source range issue

### DIFF
--- a/Sources/Markdown/Parser/CommonMarkConverter.swift
+++ b/Sources/Markdown/Parser/CommonMarkConverter.swift
@@ -611,7 +611,7 @@ struct MarkupParser {
     static func parseString(_ string: String, source: URL?, options: ParseOptions) -> Document {
         cmark_gfm_core_extensions_ensure_registered()
 
-        var cmarkOptions = CMARK_OPT_TABLE_SPANS
+        var cmarkOptions = CMARK_OPT_TABLE_SPANS | CMARK_OPT_SOURCEPOS
         if !options.contains(.disableSmartOpts) {
             cmarkOptions |= CMARK_OPT_SMART
         }

--- a/Sources/Markdown/Parser/CommonMarkConverter.swift
+++ b/Sources/Markdown/Parser/CommonMarkConverter.swift
@@ -611,9 +611,12 @@ struct MarkupParser {
     static func parseString(_ string: String, source: URL?, options: ParseOptions) -> Document {
         cmark_gfm_core_extensions_ensure_registered()
 
-        var cmarkOptions = CMARK_OPT_TABLE_SPANS | CMARK_OPT_SOURCEPOS
+        var cmarkOptions = CMARK_OPT_TABLE_SPANS
         if !options.contains(.disableSmartOpts) {
             cmarkOptions |= CMARK_OPT_SMART
+        }
+        if !options.contains(.disableSourcePosOpts) {
+            cmarkOptions |= CMARK_OPT_SOURCEPOS
         }
         
         let parser = cmark_parser_new(cmarkOptions)

--- a/Sources/Markdown/Parser/ParseOptions.swift
+++ b/Sources/Markdown/Parser/ParseOptions.swift
@@ -22,10 +22,13 @@ public struct ParseOptions: OptionSet {
     /// Enable interpretation of symbol links from inline code spans surrounded by two backticks.
     public static let parseSymbolLinks = ParseOptions(rawValue: 1 << 1)
     
-    /// Disable converting straight quotes to curly, --- to em dashes, -- to en dashes during parsing
+    /// Disable converting straight quotes to curly, --- to em dashes, -- to en dashes during parsing.
     public static let disableSmartOpts = ParseOptions(rawValue: 1 << 2)
 
     /// Parse a limited set of Doxygen commands. Requires ``parseBlockDirectives``.
     public static let parseMinimalDoxygen = ParseOptions(rawValue: 1 << 3)
+
+    /// Disable including a `data-sourcepos` attribute on all block elements during parsing.
+    public static let disableSourcePosOpts = ParseOptions(rawValue: 1 << 4)
 }
 

--- a/Tests/MarkdownTests/Inline Nodes/SymbolLinkTests.swift
+++ b/Tests/MarkdownTests/Inline Nodes/SymbolLinkTests.swift
@@ -46,4 +46,19 @@ class SymbolLinkTests: XCTestCase {
             XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
         }
     }
+
+    func testMultilineSymbolLink() {
+        let source = """
+        Test of a ``multi
+        line symbolink``
+        """
+        let document = Document(parsing: source, options: .parseSymbolLinks)
+        let expectedDump = """
+            Document @1:1-2:17
+            └─ Paragraph @1:1-2:17
+               ├─ Text @1:1-1:11 "Test of a "
+               └─ SymbolLink @1:11-2:17 destination: multi line symbolink
+            """
+        XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
+    }
 }

--- a/Tests/MarkdownTests/Parsing/BacktickTests.swift
+++ b/Tests/MarkdownTests/Parsing/BacktickTests.swift
@@ -36,7 +36,7 @@ class BacktickTests: XCTestCase {
         XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
     }
 
-    func testOpenBackticks(){
+    func testOpenBackticks() {
         let double = "``"
         let document = Document(parsing: double)
         let expectedDump = """


### PR DESCRIPTION
Bug/issue #, if applicable: 

Close #142

## Summary

Fix the unexpected source range issue for multi line symbol link

For detail see https://github.com/apple/swift-markdown/issues/142#issuecomment-1748504438

2 question to be discussed:
1. Should we add CMARK_OPT_SOURCEPOS by default the same as CMARK_OPT_TABLE_SPANS?
2. Should we add a new ParseOptions case so that client of Markdown can choose to opt-in or opt-out this option?

## Dependencies

None

## Testing

Add testMultilineSymbolLink test case

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
