### PR TITLE
associate BlockMarkup.md with the BlockMarkup type

### DIFF
--- a/Sources/Markdown/Markdown.docc/Markdown/BlockMarkup.md
+++ b/Sources/Markdown/Markdown.docc/Markdown/BlockMarkup.md
@@ -1,4 +1,4 @@
-# Markup Block Nodes
+# ``BlockMarkup``
 
 ## Topics
 


### PR DESCRIPTION
this markdown article is running into a DocC bug where it replaces the `BlockMarkup` symbol, which causes some rather strange rendering:

![image](https://github.com/apple/swift-markdown/assets/2556986/47795ab4-2f48-4b34-a958-3258d41d4504)

this PR associates the article properly to the `BlockMarkup` symbol by turning the article into a markdown supplement. 
