### PR TITLE
build: silence warning about CMakeLists.txt from SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,8 @@ let package = Package(
                 "CAtomic",
                 .product(name: "cmark-gfm", package: cmarkPackageName),
                 .product(name: "cmark-gfm-extensions", package: cmarkPackageName),
+            ], exclude: [
+                "CMakeLists.txt"
             ]),
         .testTarget(
             name: "MarkdownTests",


### PR DESCRIPTION
Ignore the CMakeLists.txt which is used for the CMake build to support swift-format.

Fixes: #166 