### PR TITLE
Fix whitespace issues with block directive formatting

### DIFF
--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -463,7 +463,7 @@ public struct MarkupFormatter: MarkupWalker {
                 } else if let numeralPrefix = numeralPrefix(for: parentListItem) {
                     prefix += String(repeating: " ", count: numeralPrefix.count)
                 }
-            } else if element is BlockDirective && element.parent is BlockDirective {
+            } else if element.parent is BlockDirective {
                 prefix += "    "
             }
         }
@@ -1105,9 +1105,6 @@ public struct MarkupFormatter: MarkupWalker {
     }
 
     public mutating func visitBlockDirective(_ blockDirective: BlockDirective) {
-        if blockDirective.parent is BlockDirective {
-            ensurePrecedingNewlineCount(atLeast: 1)
-        }
         if blockDirective.indexInParent > 0 {
             ensurePrecedingNewlineCount(atLeast: 2)
         }
@@ -1129,6 +1126,7 @@ public struct MarkupFormatter: MarkupWalker {
 
         if blockDirective.childCount > 0 {
             print(" {", for: blockDirective)
+            queueNewline()
         }
 
         descendInto(blockDirective)

--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -463,7 +463,8 @@ public struct MarkupFormatter: MarkupWalker {
                 } else if let numeralPrefix = numeralPrefix(for: parentListItem) {
                     prefix += String(repeating: " ", count: numeralPrefix.count)
                 }
-            } else if element.parent is BlockDirective {
+            }
+            if element.parent is BlockDirective {
                 prefix += "    "
             }
         }

--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -463,7 +463,7 @@ public struct MarkupFormatter: MarkupWalker {
                 } else if let numeralPrefix = numeralPrefix(for: parentListItem) {
                     prefix += String(repeating: " ", count: numeralPrefix.count)
                 }
-            } else if element is BlockDirective {
+            } else if element is BlockDirective && element.parent is BlockDirective {
                 prefix += "    "
             }
         }
@@ -1105,7 +1105,12 @@ public struct MarkupFormatter: MarkupWalker {
     }
 
     public mutating func visitBlockDirective(_ blockDirective: BlockDirective) {
-        ensurePrecedingNewlineCount(atLeast: 1)
+        if blockDirective.parent is BlockDirective {
+            ensurePrecedingNewlineCount(atLeast: 1)
+        }
+        if blockDirective.indexInParent > 0 {
+            ensurePrecedingNewlineCount(atLeast: 2)
+        }
         print("@", for: blockDirective)
         print(blockDirective.name, for: blockDirective)
 
@@ -1128,9 +1133,8 @@ public struct MarkupFormatter: MarkupWalker {
 
         descendInto(blockDirective)
 
-        queueNewline()
-
         if blockDirective.childCount > 0 {
+            queueNewline()
             print("}", for: blockDirective)
         }
     }

--- a/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
@@ -1553,19 +1553,40 @@ class MarkupFormatterTableTests: XCTestCase {
 
 class MarkupFormatterMixedContentTests: XCTestCase {
     func testMixedContentWithBlockDirectives() {
-        let expected = #"""
-        # Example title
+        let expected = [
+            #"""
+            # Example title
 
-        @Metadata {
-            @TitleHeading(example)
-        }
-        """#
-        let printed = Document(
-            Heading(level: 1, Text("Example title")),
-            BlockDirective(name: "Metadata", children: [
-                BlockDirective(name: "TitleHeading", argumentText: "example"),
-            ])
-        ).format()
-        XCTAssertEqual(expected, printed)
+            @Metadata {
+                @TitleHeading(example)
+            }
+            """#,
+            #"""
+            @Tutorials(name: Foo) {
+                @Intro(title: Bar) {
+                    Foobar
+                    
+                    @Image(source: foo, alt: bar)
+                }
+            }
+            """#,
+        ]
+        let printed = [
+            Document(
+                Heading(level: 1, Text("Example title")),
+                BlockDirective(name: "Metadata", children: [
+                    BlockDirective(name: "TitleHeading", argumentText: "example"),
+                ])
+            ).format(),
+            Document(
+                BlockDirective(name: "Tutorials", argumentText: "name: Foo", children: [
+                    BlockDirective(name: "Intro", argumentText: "title: Bar", children: [
+                        Paragraph(Text("Foobar")) as BlockMarkup,
+                        BlockDirective(name: "Image", argumentText: "source: foo, alt: bar") as BlockMarkup,
+                    ]),
+                ])
+            ).format(),
+        ]
+        zip(expected, printed).forEach { XCTAssertEqual($0, $1) }
     }
 }

--- a/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
@@ -376,6 +376,18 @@ class MarkupFormatterSingleElementTests: XCTestCase {
         )).format()
         XCTAssertEqual(expected, printed)
     }
+
+    func testPrintBlockDirective() {
+        let expected = #"""
+        @Metadata {
+            @TitleHeading(Example)
+        }
+        """#
+        let printed = BlockDirective(name: "Metadata", children: [
+            BlockDirective(name: "TitleHeading", argumentText: "Example"),
+        ]).format()
+        XCTAssertEqual(expected, printed)
+    }
 }
 
 /// Tests that formatting options work correctly.

--- a/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
@@ -1550,3 +1550,22 @@ class MarkupFormatterTableTests: XCTestCase {
         XCTAssertTrue(document.hasSameStructure(as: reparsed))
     }
 }
+
+class MarkupFormatterMixedContentTests: XCTestCase {
+    func testMixedContentWithBlockDirectives() {
+        let expected = #"""
+        # Example title
+
+        @Metadata {
+            @TitleHeading(example)
+        }
+        """#
+        let printed = Document(
+            Heading(level: 1, Text("Example title")),
+            BlockDirective(name: "Metadata", children: [
+                BlockDirective(name: "TitleHeading", argumentText: "example"),
+            ])
+        ).format()
+        XCTAssertEqual(expected, printed)
+    }
+}

--- a/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
@@ -1545,10 +1545,8 @@ class MarkupFormatterTableTests: XCTestCase {
         """
 
         XCTAssertEqual(expected, formatted)
-        print(formatted)
 
         let reparsed = Document(parsing: formatted)
-        print(reparsed.debugDescription())
         XCTAssertTrue(document.hasSameStructure(as: reparsed))
     }
 }

--- a/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
@@ -1570,6 +1570,14 @@ class MarkupFormatterMixedContentTests: XCTestCase {
                 }
             }
             """#,
+            #"""
+            # Example title
+
+            @Links(visualStyle: list) {
+                - ``Foo``
+                - ``Bar``
+            }
+            """#,
         ]
         let printed = [
             Document(
@@ -1583,6 +1591,15 @@ class MarkupFormatterMixedContentTests: XCTestCase {
                     BlockDirective(name: "Intro", argumentText: "title: Bar", children: [
                         Paragraph(Text("Foobar")) as BlockMarkup,
                         BlockDirective(name: "Image", argumentText: "source: foo, alt: bar") as BlockMarkup,
+                    ]),
+                ])
+            ).format(),
+            Document(
+                Heading(level: 1, Text("Example title")),
+                BlockDirective(name: "Links", argumentText: "visualStyle: list", children: [
+                    UnorderedList([
+                        ListItem(Paragraph(SymbolLink(destination: "Foo"))),
+                        ListItem(Paragraph(SymbolLink(destination: "Bar"))),
                     ]),
                 ])
             ).format(),

--- a/Tests/MarkdownTests/Visitors/MarkupTreeDumperTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupTreeDumperTests.swift
@@ -95,7 +95,6 @@ final class MarkupTreeDumperTests: XCTestCase {
         └─ HTMLBlock @42:1-42:90 #71
            <!-- Copyright (c) 2021 Apple Inc and the Swift Project authors. All Rights Reserved. -->
         """
-        print(everythingDocument.debugDescription(options: [.printEverything]))
         XCTAssertEqual(expectedDump, everythingDocument.debugDescription(options: [.printEverything]))
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

Fixes the following issues with block directive formatting
* top-level/starting block directive has unnecessary preceding newline
* top-level block directive is unexpectedly indented
* nested block directive has unnecessary newline before "}" character

For example:

```swift
import Markdown
print(Document(
    BlockDirective(name: "Metadata", children: [
        BlockDirective(name: "TitleHeading", argumentText: "Example")
    ])
).format())
```

Expected output:
```
@Metadata {
    @TitleHeading(Example)
}
```

Actual output:
```

    @Metadata {
        @TitleHeading(Example)
    }
```

## Testing

Steps:
1. Create a new Snippet that calls `format()` on a document with block directives
2. Verify that the printed markdown doesn't exhibit the noted issues

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary
