### PR TITLE
Update `swift-cmark` reference to `swiftlang` org

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-cmark.git", branch: "gfm"),
+        .package(url: "https://github.com/swiftlang/swift-cmark.git", branch: "gfm"),
     ]
     
     // SwiftPM command plugins are only supported by Swift version 5.6 and later.


### PR DESCRIPTION
We're seeing issues with GitHub failing to follow the redirect, so it might help to get this updated to the new org.