### PR TITLE
Mixed ordered and unordered list hierarchies should indent consistently

### DIFF
--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -425,21 +425,20 @@ public struct MarkupFormatter: MarkupWalker {
      */
     func linePrefix(for element: Markup) -> String {
         var prefix = formattingOptions.customLinePrefix
-        var unorderedListCount = 0
-        var orderedListCount = 0
+        var listCount = 0
         for element in element.parentalChain {
             if element is BlockQuote {
                 prefix += "> "
             } else if element is UnorderedList {
-                if unorderedListCount > 0 {
+                if listCount > 0 {
                     prefix += "  "
                 }
-                unorderedListCount += 1
+                listCount += 1
             } else if element is OrderedList {
-                if orderedListCount > 0 {
+                if listCount > 0 {
                     prefix += "   "
                 }
-                orderedListCount += 1
+                listCount += 1
             } else if !(element is ListItem),
                 let parentListItem = element.parent as? ListItem {
                 /*


### PR DESCRIPTION
## Summary

Mixed nested ordered and unordered lists causes indentation prefixes to get dropped in some cases.

## Details

Input like this (but starting in the first column; using CODE blocks here):

```markdown
- This is a top-level bulleted list
  - This is second-level bulleted list
  - Second of the second
    1. This is ordered and second-order nested
    1. Second entry of same
```
should render like:

```markdown
* This is a top-level bulleted list
  * This is second-level bulleted list
  * Second of the second
    1. This is ordered and second-order nested
    2. Second entry of same
```
given formatting options `unorderedListMarker: .star`, `orderedListNumerals:.incrementing(start: 1)`, and `emphasisMarker: .underline`.

However, before this change, they render like:

```markdown
* This is a top-level bulleted list
  * This is second-level bulleted list
  * Second of the second
  1. This is ordered and second-order nested
  2. Second entry of same
```
in which the prefix is not generated for the ordered list.  The dump of the tree is correct, however:

```
    Document
    └─ UnorderedList
       └─ ListItem
          ├─ Paragraph
          │  └─ Text "This is a top-level bulleted list"
          └─ UnorderedList
             ├─ ListItem
             │  └─ Paragraph
             │     └─ Text "This is second-level bulleted list"
             └─ ListItem
                ├─ Paragraph
                │  └─ Text "Second of the second"
                └─ OrderedList
                   ├─ ListItem
                   │  └─ Paragraph
                   │     └─ Text "This is ordered and second-order nested"
                   └─ ListItem
                      └─ Paragraph
                         └─ Text "Second entry of same"
```

The above AST shows that the OrderedList is a child of the ListItem and not of the UnorderedList, so it should be indented accordingly when rendered.

## Dependencies

None

## Testing

I sanity tested with the above examples and ran on some other markdown to verify that the output seems sane.