### PR TITLE
Revert "fixUnsafeFlags"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,14 +14,6 @@ import class Foundation.ProcessInfo
 
 let cmarkPackageName = ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil ? "swift-cmark" : "cmark"
 
-// On non-Windows, do not include unsafe flags so SwiftPM allows tagged dependency usage.
-var markdownSwiftSettings: [SwiftSetting] = []
-#if os(Windows)
-markdownSwiftSettings.append(
-    .unsafeFlags(["-Xcc", "-DCMARK_GFM_STATIC_DEFINE"], .when(platforms: [.windows]))
-)
-#endif
-
 let package = Package(
     name: "swift-markdown",
     products: [
@@ -40,8 +32,10 @@ let package = Package(
             exclude: [
                 "CMakeLists.txt"
             ],
-            swiftSettings: markdownSwiftSettings
-        ),
+            swiftSettings: [
+                .unsafeFlags(["-Xcc", "-DCMARK_GFM_STATIC_DEFINE"],
+                             .when(platforms: [.windows])),
+            ]),
         .testTarget(
             name: "MarkdownTests",
             dependencies: ["Markdown"],


### PR DESCRIPTION
This reverts commit 8ad5dcc94ee06c835152f183898464b6a068d6cd.

The `#if os(Windows)` guard controls the _build_ not the _host_. This prevents cross-compilation of the package. Revert the incorrect change.