### PR TITLE
Revert "Add preceding newlines before Doxygen commands"

### DIFF
--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -1174,47 +1174,27 @@ public struct MarkupFormatter: MarkupWalker {
     }
 
     public mutating func visitDoxygenDiscussion(_ doxygenDiscussion: DoxygenDiscussion) {
-        if doxygenDiscussion.indexInParent > 0 {
-            ensurePrecedingNewlineCount(atLeast: 2)
-        }
-
         printDoxygenStart("discussion", for: doxygenDiscussion)
         descendInto(doxygenDiscussion)
     }
 
     public mutating func visitDoxygenAbstract(_ doxygenAbstract: DoxygenAbstract) {
-        if doxygenAbstract.indexInParent > 0 {
-            ensurePrecedingNewlineCount(atLeast: 2)
-        }
-
         printDoxygenStart("abstract", for: doxygenAbstract)
         descendInto(doxygenAbstract)
     }
 
     public mutating func visitDoxygenNote(_ doxygenNote: DoxygenNote) {
-        if doxygenNote.indexInParent > 0 {
-            ensurePrecedingNewlineCount(atLeast: 2)
-        }
-
         printDoxygenStart("note", for: doxygenNote)
         descendInto(doxygenNote)
     }
 
     public mutating func visitDoxygenParameter(_ doxygenParam: DoxygenParameter) {
-        if doxygenParam.indexInParent > 0 {
-            ensurePrecedingNewlineCount(atLeast: 2)
-        }
-
         printDoxygenStart("param", for: doxygenParam)
         print("\(doxygenParam.name) ", for: doxygenParam)
         descendInto(doxygenParam)
     }
 
     public mutating func visitDoxygenReturns(_ doxygenReturns: DoxygenReturns) {
-        if doxygenReturns.indexInParent > 0 {
-            ensurePrecedingNewlineCount(atLeast: 2)
-        }
-
         // FIXME: store the actual command name used in the original markup
         printDoxygenStart("returns", for: doxygenReturns)
         descendInto(doxygenReturns)

--- a/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
@@ -1626,31 +1626,4 @@ class MarkupFormatterMixedContentTests: XCTestCase {
         ]
         zip(expected, printed).forEach { XCTAssertEqual($0, $1) }
     }
-
-    func testDoxygenCommandsWithPrecedingNewlines() {
-        let expected = #"""
-            Does something.
-
-            \abstract abstract
-
-            \param x first param
-
-            \returns result
-
-            \note note
-
-            \discussion discussion
-            """#
-
-        let printed = Document(
-            Paragraph(Text("Does something.")),
-            DoxygenAbstract(children: Paragraph(Text("abstract"))),
-            DoxygenParameter(name: "x", children: Paragraph(Text("first param"))),
-            DoxygenReturns(children: Paragraph(Text("result"))),
-            DoxygenNote(children: Paragraph(Text("note"))),
-            DoxygenDiscussion(children: Paragraph(Text("discussion")))
-        ).format()
-
-        XCTAssertEqual(expected, printed)
-    }
 }


### PR DESCRIPTION
Reverts https://github.com/swiftlang/swift-markdown/pull/237

This broke a test in DocC and thus is blocking the swift compiler's CI: https://ci.swift.org/job/oss-swift-pr-test-macoss/5558/

related to: rdar://163704908