### PR TITLE
Fix #238 out of bounds crash when formatting tables

### DIFF
--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -1031,7 +1031,7 @@ public struct MarkupFormatter: MarkupWalker {
         /// the default span of 1, where it will only return the `finalColumnWidths` value for the
         /// given `column`.
         func columnWidth(column: Int, colspan: Int) -> Int {
-            let lastColumn = column + colspan
+            let lastColumn = min(finalColumnWidths.count, column + colspan)
             return (column..<lastColumn).map({ finalColumnWidths[$0] }).reduce(0, { $0 + $1 })
         }
 

--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -1031,8 +1031,7 @@ public struct MarkupFormatter: MarkupWalker {
         /// the default span of 1, where it will only return the `finalColumnWidths` value for the
         /// given `column`.
         func columnWidth(column: Int, colspan: Int) -> Int {
-            let lastColumn = min(finalColumnWidths.count, column + colspan)
-            return (column..<lastColumn).map({ finalColumnWidths[$0] }).reduce(0, { $0 + $1 })
+            finalColumnWidths.dropFirst(column).prefix(colspan).reduce(0, +)
         }
 
         // We now know the width that each printed column will be.

--- a/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
@@ -1569,6 +1569,38 @@ class MarkupFormatterTableTests: XCTestCase {
         let reparsed = Document(parsing: formatted)
         XCTAssertTrue(document.hasSameStructure(as: reparsed))
     }
+    
+    func testColSpanOverflowTooManyIndicators() {
+        let source = """
+        | Jenis Kelamin | Jenis Tas     | Tally       | Jumlah |
+        |---------------|---------------|-------------|--------|
+        | Perempuan     | Tas Ransel    | ||||
+        """
+        let document = Document(parsing: source)
+        let formatted = document.format()
+        let expected = """
+        |Jenis Kelamin|Jenis Tas |Tally|Jumlah|
+        |-------------|----------|-----|------|
+        |Perempuan    |Tas Ransel|           ||
+        """
+        XCTAssertEqual(expected, formatted)
+    }
+    
+    func testColSpanOverflowMisformatted() {
+        let source = """
+        |A|B|C|
+        |-|-|-|
+        |1|2|3||4|5|6|
+        """
+        let document = Document(parsing: source)
+        let formatted = document.format()
+        let expected = """
+        |A|B|C|
+        |-|-|-|
+        |1|2|3|
+        """
+        XCTAssertEqual(expected, formatted)
+    }
 }
 
 class MarkupFormatterMixedContentTests: XCTestCase {

--- a/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
@@ -1601,6 +1601,29 @@ class MarkupFormatterTableTests: XCTestCase {
         """
         XCTAssertEqual(expected, formatted)
     }
+    
+    func testColSpanOverflowInHeader() {
+        // Doesn't get parsed as a table, so doesn't exhibit the crash
+        let source = """
+        |A|B|C||-|-|-|
+        |1|2|3|
+        """
+        let document = Document(parsing: source)
+        let formatted = document.format()
+        XCTAssertEqual(source, formatted)
+    }
+    
+    func testColSpanOverflowInSubHeader() {
+        // Doesn't get parsed as a table, so doesn't exhibit the crash
+        let source = """
+        |A|B|C|
+        |-|-|-||
+        |1|2|3|
+        """
+        let document = Document(parsing: source)
+        let formatted = document.format()
+        XCTAssertEqual(source, formatted)
+    }
 }
 
 class MarkupFormatterMixedContentTests: XCTestCase {


### PR DESCRIPTION
Bug/issue #, if applicable: #238 

## Summary

If a table included multiple pipe characters that took the total number of columns (including spanning columns) above the main column count, this would cause a crash instead of just dropping the excess content as per the spec.

This PR removes the attempted out-of-bounds read of the widths array by capping the count. 

## Dependencies

None

## Testing

Two unit tests have been added to exercise the code. To manually test it, you can attempt to parse markdown like this:

```
|A|B|C|
|-|-|-|
|1|2|3||4|5|6|
```

And then `format` the resulting document, which will crash without these changes in place. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary (not applicable)
