### PR TITLE
Fix #238 out of bounds crash when formatting tables (#250)

### DIFF
--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -1031,8 +1031,7 @@ public struct MarkupFormatter: MarkupWalker {
         /// the default span of 1, where it will only return the `finalColumnWidths` value for the
         /// given `column`.
         func columnWidth(column: Int, colspan: Int) -> Int {
-            let lastColumn = column + colspan
-            return (column..<lastColumn).map({ finalColumnWidths[$0] }).reduce(0, { $0 + $1 })
+            finalColumnWidths.dropFirst(column).prefix(colspan).reduce(0, +)
         }
 
         // We now know the width that each printed column will be.

--- a/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
@@ -1569,6 +1569,61 @@ class MarkupFormatterTableTests: XCTestCase {
         let reparsed = Document(parsing: formatted)
         XCTAssertTrue(document.hasSameStructure(as: reparsed))
     }
+    
+    func testColSpanOverflowTooManyIndicators() {
+        let source = """
+        | Jenis Kelamin | Jenis Tas     | Tally       | Jumlah |
+        |---------------|---------------|-------------|--------|
+        | Perempuan     | Tas Ransel    | ||||
+        """
+        let document = Document(parsing: source)
+        let formatted = document.format()
+        let expected = """
+        |Jenis Kelamin|Jenis Tas |Tally|Jumlah|
+        |-------------|----------|-----|------|
+        |Perempuan    |Tas Ransel|           ||
+        """
+        XCTAssertEqual(expected, formatted)
+    }
+    
+    func testColSpanOverflowMisformatted() {
+        let source = """
+        |A|B|C|
+        |-|-|-|
+        |1|2|3||4|5|6|
+        """
+        let document = Document(parsing: source)
+        let formatted = document.format()
+        let expected = """
+        |A|B|C|
+        |-|-|-|
+        |1|2|3|
+        """
+        XCTAssertEqual(expected, formatted)
+    }
+    
+    func testColSpanOverflowInHeader() {
+        // Doesn't get parsed as a table, so doesn't exhibit the crash
+        let source = """
+        |A|B|C||-|-|-|
+        |1|2|3|
+        """
+        let document = Document(parsing: source)
+        let formatted = document.format()
+        XCTAssertEqual(source, formatted)
+    }
+    
+    func testColSpanOverflowInSubHeader() {
+        // Doesn't get parsed as a table, so doesn't exhibit the crash
+        let source = """
+        |A|B|C|
+        |-|-|-||
+        |1|2|3|
+        """
+        let document = Document(parsing: source)
+        let formatted = document.format()
+        XCTAssertEqual(source, formatted)
+    }
 }
 
 class MarkupFormatterMixedContentTests: XCTestCase {


### PR DESCRIPTION
- **Explanation**:

Fixes an out-of-bounds crash when processing tables
- **Scope**:

Bug fix

- **Issues**:

#238

- **Original PRs**:

#250 

- **Risk**:

Very low. Code change prevents out-of-bounds access and should provide equivalent results for non-erroneous inputs

- **Testing**:

Tests added as part of PR 

- **Reviewers**:

@QuietMisdreavus 