### PR TITLE
Fix #254 preventing the crash when cmark reports a line number (like …

### DIFF
--- a/Sources/Markdown/Parser/RangeAdjuster.swift
+++ b/Sources/Markdown/Parser/RangeAdjuster.swift
@@ -26,11 +26,19 @@ struct RangeAdjuster: MarkupWalker {
         /// to be filled in from cmark.
         let adjustedRange = markup.range.map { range -> SourceRange in
             // Add back the offset to the column as if the indentation weren't stripped.
+            func indentation(for cmarkLine: Int) -> Int {
+                let index = cmarkLine - 1
+                guard !trimmedIndentationPerLine.isEmpty else { return 0 }
+                // Clamp index to valid range
+                let safeIndex = min(max(0, index), trimmedIndentationPerLine.count - 1)
+                return trimmedIndentationPerLine[safeIndex]
+            }
+
             let start = SourceLocation(line: startLine + range.lowerBound.line - 1,
-                                       column: range.lowerBound.column + (trimmedIndentationPerLine[range.lowerBound.line - 1] ),
+                                       column: range.lowerBound.column + indentation(for: range.lowerBound.line),
                                        source: range.lowerBound.source)
             let end = SourceLocation(line: startLine + range.upperBound.line - 1,
-                                     column: range.upperBound.column + (trimmedIndentationPerLine[range.upperBound.line - 1]),
+                                     column: range.upperBound.column + indentation(for: range.upperBound.line),
                                      source: range.upperBound.source)
             return start..<end
         }

--- a/Tests/MarkdownTests/Block Nodes/DocumentTests.swift
+++ b/Tests/MarkdownTests/Block Nodes/DocumentTests.swift
@@ -59,4 +59,41 @@ final class DocumentTests: XCTestCase {
                 """
         XCTAssertEqual(expectedDump, document.debugDescription())
     }
+    
+    func testParsingBlockDirectiveWithCRLFLineEndings() {
+        let input = "@Comment {\r\n    This is a comment\r}\n"
+        let options: ParseOptions = [.parseBlockDirectives, .parseSymbolLinks]
+        let document = Document(parsing: input, options: options)
+        XCTAssertNotNil(document)
+    }
+    
+    func testParsingNestedBlockDirectivesWithMixedCRLFLineEndings() {
+        let input = "@Outer {\n    @Inner {\r\n        content\n    }\r\n}\r\n"
+        let options: ParseOptions = [.parseBlockDirectives, .parseSymbolLinks]
+        let document = Document(parsing: input, options: options)
+        XCTAssertNotNil(document)
+    }
+    
+    func testParsingSimpleFileCRLFLineEndings() {
+        let input = "4bf5d-496d7\r\n04c8f-c1484\r\n622aa-0210e\r\n1bf50-1f7e2\r\nfdc17-d25e2\r\n4de63-510a3\r\n"
+        let options: ParseOptions = [.parseBlockDirectives, .parseSymbolLinks]
+        let document = Document(parsing: input, options: options)
+        XCTAssertNotNil(document)
+        let expectedDump = """
+                Document
+                └─ Paragraph
+                   ├─ Text "4bf5d-496d7"
+                   ├─ SoftBreak
+                   ├─ Text "04c8f-c1484"
+                   ├─ SoftBreak
+                   ├─ Text "622aa-0210e"
+                   ├─ SoftBreak
+                   ├─ Text "1bf50-1f7e2"
+                   ├─ SoftBreak
+                   ├─ Text "fdc17-d25e2"
+                   ├─ SoftBreak
+                   └─ Text "4de63-510a3"
+                """
+        XCTAssertEqual(expectedDump, document.debugDescription())
+    }
 }


### PR DESCRIPTION
…a trailing newline) that exceeds the lines we tracked

Bug/issue #, if applicable: 254


## Testing

_Check my Issue 254._

