### PR TITLE
Add block math parsing for $$ delimiters(LaTex style)

### DIFF
--- a/Sources/Markdown/Base/Document.swift
+++ b/Sources/Markdown/Base/Document.swift
@@ -42,12 +42,14 @@ public extension Document {
     /// - parameter source: an explicit source URL from which the input `string` came for marking source locations.
     ///   This need not be a file URL.
     init(parsing string: String, source: URL? = nil, options: ParseOptions = []) {
+        let document: Document
         if options.contains(.parseBlockDirectives) {
-            self = BlockDirectiveParser.parse(string, source: source,
-                                              options: options)
+            document = BlockDirectiveParser.parse(string, source: source,
+                                                  options: options)
         } else {
-            self = MarkupParser.parseString(string, source: source, options: options)
+            document = MarkupParser.parseString(string, source: source, options: options)
         }
+        self = MathParser.parse(document, options: options)
     }
 
     /// Parse a file's contents into a `Document`.
@@ -56,12 +58,14 @@ public extension Document {
     /// - parameter options: options for parsing Markdown text.
     init(parsing file: URL, options: ParseOptions = []) throws {
         let string = try String(contentsOf: file)
+        let document: Document
         if options.contains(.parseBlockDirectives) {
-            self = BlockDirectiveParser.parse(string, source: file,
-                                              options: options)
+            document = BlockDirectiveParser.parse(string, source: file,
+                                                  options: options)
         } else {
-            self = MarkupParser.parseString(string, source: file, options: options)
+            document = MarkupParser.parseString(string, source: file, options: options)
         }
+        self = MathParser.parse(document, options: options)
     }
 
     /// Create a document from a sequence of block markup elements.

--- a/Sources/Markdown/Base/Markup.swift
+++ b/Sources/Markdown/Base/Markup.swift
@@ -25,6 +25,8 @@ func makeMarkup(_ data: _MarkupData) -> Markup {
         return ThematicBreak(data)
     case .htmlBlock:
         return HTMLBlock(data)
+    case .blockMath:
+        return BlockMath(data)
     case .listItem:
         return ListItem(data)
     case .orderedList:
@@ -35,6 +37,8 @@ func makeMarkup(_ data: _MarkupData) -> Markup {
         return Paragraph(data)
     case .blockDirective:
         return BlockDirective(data)
+    case .inlineMath:
+        return InlineMath(data)
     case .inlineCode:
         return InlineCode(data)
     case .customInline:
@@ -408,4 +412,3 @@ fileprivate struct SoftBreakDeleter: MarkupRewriter {
         return Text(" ")
     }
 }
-

--- a/Sources/Markdown/Base/RawMarkup.swift
+++ b/Sources/Markdown/Base/RawMarkup.swift
@@ -23,12 +23,14 @@ enum RawMarkupData: Equatable {
     case heading(level: Int)
     case thematicBreak
     case htmlBlock(String)
+    case blockMath(String)
     case listItem(checkbox: Checkbox?)
     case orderedList(startIndex: UInt = 1)
     case unorderedList
     case paragraph
     case blockDirective(name: String, nameLocation: SourceLocation?, arguments: DirectiveArgumentText)
 
+    case inlineMath(String)
     case inlineCode(String)
     case customInline(String)
     case emphasis
@@ -239,6 +241,10 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
         return .create(data: .htmlBlock(html), parsedRange: parsedRange, children: [])
     }
 
+    static func blockMath(parsedRange: SourceRange?, code: String) -> RawMarkup {
+        return .create(data: .blockMath(code), parsedRange: parsedRange, children: [])
+    }
+
     static func listItem(checkbox: Checkbox?, parsedRange: SourceRange?, _ children: [RawMarkup]) -> RawMarkup {
         return .create(data: .listItem(checkbox: checkbox), parsedRange: parsedRange, children: children)
     }
@@ -260,6 +266,10 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
     }
 
     // MARK: Inline Creation
+
+    static func inlineMath(parsedRange: SourceRange?, code: String) -> RawMarkup {
+        return .create(data: .inlineMath(code), parsedRange: parsedRange, children: [])
+    }
 
     static func inlineCode(parsedRange: SourceRange?, code: String) -> RawMarkup {
         return .create(data: .inlineCode(code), parsedRange: parsedRange, children: [])

--- a/Sources/Markdown/Block Nodes/Leaf Blocks/BlockMath.swift
+++ b/Sources/Markdown/Block Nodes/Leaf Blocks/BlockMath.swift
@@ -1,0 +1,53 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// A block math element surrounded by `$$` delimiters.
+public struct BlockMath: BlockMarkup, LiteralMarkup {
+    public var _data: _MarkupData
+
+    init(_ raw: RawMarkup) throws {
+        guard case .blockMath = raw.data else {
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: BlockMath.self)
+        }
+        let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
+        self.init(_MarkupData(absoluteRaw))
+    }
+
+    init(_ data: _MarkupData) {
+        self._data = data
+    }
+}
+
+// MARK: - Public API
+
+public extension BlockMath {
+    init(_ literalText: String) {
+        try! self.init(.blockMath(parsedRange: nil, code: literalText))
+    }
+
+    /// The raw math code between `$$` delimiters.
+    var code: String {
+        get {
+            guard case let .blockMath(code) = _data.raw.markup.data else {
+                fatalError("\(self) markup wrapped unexpected \(_data.raw)")
+            }
+            return code
+        }
+        set {
+            _data = _data.replacingSelf(.blockMath(parsedRange: nil, code: newValue))
+        }
+    }
+
+    // MARK: Visitation
+
+    func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
+        return visitor.visitBlockMath(self)
+    }
+}

--- a/Sources/Markdown/CMakeLists.txt
+++ b/Sources/Markdown/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(Markdown
   "Block Nodes/Block Container Blocks/OrderedList.swift"
   "Block Nodes/Block Container Blocks/UnorderedList.swift"
   "Block Nodes/Inline Container Blocks/Paragraph.swift"
+  "Block Nodes/Leaf Blocks/BlockMath.swift"
   "Block Nodes/Leaf Blocks/CodeBlock.swift"
   "Block Nodes/Leaf Blocks/Heading.swift"
   "Block Nodes/Leaf Blocks/HTMLBlock.swift"
@@ -48,6 +49,7 @@ add_library(Markdown
   "Inline Nodes/Inline Containers/Strikethrough.swift"
   "Inline Nodes/Inline Containers/Strong.swift"
   "Inline Nodes/Inline Leaves/CustomInline.swift"
+  "Inline Nodes/Inline Leaves/InlineMath.swift"
   "Inline Nodes/Inline Leaves/InlineCode.swift"
   "Inline Nodes/Inline Leaves/InlineHTML.swift"
   "Inline Nodes/Inline Leaves/LineBreak.swift"
@@ -58,6 +60,7 @@ add_library(Markdown
   Parser/BlockDirectiveParser.swift
   Parser/CommonMarkConverter.swift
   Parser/LazySplitLines.swift
+  Parser/MathParser.swift
   Parser/ParseOptions.swift
   Parser/RangeAdjuster.swift
   Parser/RangerTracker.swift

--- a/Sources/Markdown/Inline Nodes/Inline Leaves/InlineMath.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Leaves/InlineMath.swift
@@ -1,0 +1,59 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// An inline math element surrounded by `$` delimiters.
+public struct InlineMath: RecurringInlineMarkup, LiteralMarkup {
+    public var _data: _MarkupData
+
+    init(_ raw: RawMarkup) throws {
+        guard case .inlineMath = raw.data else {
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: InlineMath.self)
+        }
+        let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
+        self.init(_MarkupData(absoluteRaw))
+    }
+
+    init(_ data: _MarkupData) {
+        self._data = data
+    }
+}
+
+// MARK: - Public API
+
+public extension InlineMath {
+    init(_ literalText: String) {
+        try! self.init(.inlineMath(parsedRange: nil, code: literalText))
+    }
+
+    /// The raw math code between `$` delimiters.
+    var code: String {
+        get {
+            guard case let .inlineMath(code) = _data.raw.markup.data else {
+                fatalError("\(self) markup wrapped unexpected \(_data.raw)")
+            }
+            return code
+        }
+        set {
+            _data = _data.replacingSelf(.inlineMath(parsedRange: nil, code: newValue))
+        }
+    }
+
+    // MARK: PlainTextConvertibleMarkup
+
+    var plainText: String {
+        return "$\(code)$"
+    }
+
+    // MARK: Visitation
+
+    func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
+        return visitor.visitInlineMath(self)
+    }
+}

--- a/Sources/Markdown/Parser/MathParser.swift
+++ b/Sources/Markdown/Parser/MathParser.swift
@@ -1,0 +1,230 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+struct MathParser {
+    static func parse(_ document: Document, options: ParseOptions) -> Document {
+        guard options.contains(.parseMath) else {
+            return document
+        }
+        var rewriter = MathRewriter()
+        guard let rewritten = rewriter.visit(document) as? Document else {
+            return document
+        }
+        return rewritten
+    }
+}
+
+fileprivate struct MathRewriter: MarkupRewriter {
+    mutating func defaultVisit(_ markup: Markup) -> Markup? {
+        var newChildren = [Markup]()
+        for child in markup.children {
+            if let text = child as? Text {
+                newChildren.append(contentsOf: splitInlineMath(in: text))
+            } else if let rewritten = visit(child) {
+                newChildren.append(rewritten)
+            }
+        }
+        return markup.withUncheckedChildren(newChildren)
+    }
+
+    mutating func visitParagraph(_ paragraph: Paragraph) -> Markup? {
+        guard let code = blockMathCode(from: paragraph) else {
+            return defaultVisit(paragraph)
+        }
+        return try! BlockMath(.blockMath(parsedRange: paragraph.range, code: code))
+    }
+
+    private func blockMathCode(from paragraph: Paragraph) -> String? {
+        var rawText = ""
+        for child in paragraph.children {
+            if let text = child as? Text {
+                rawText += text.string
+            } else if child is SoftBreak || child is LineBreak {
+                rawText += "\n"
+            } else {
+                return nil
+            }
+        }
+
+        let lines = rawText.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
+        guard !lines.isEmpty else {
+            return nil
+        }
+
+        let firstLine = lines[lines.startIndex].trimmingCharacters(in: .whitespaces)
+        let lastLine = lines[lines.index(before: lines.endIndex)].trimmingCharacters(in: .whitespaces)
+
+        if lines.count >= 2, firstLine == "$$", lastLine == "$$" {
+            return lines.dropFirst().dropLast().joined(separator: "\n")
+        }
+
+        guard lines.count == 1 else {
+            return nil
+        }
+        guard firstLine.count >= 4,
+              firstLine.hasPrefix("$$"),
+              firstLine.hasSuffix("$$") else {
+            return nil
+        }
+
+        return String(firstLine.dropFirst(2).dropLast(2))
+    }
+
+    private func splitInlineMath(in text: Text) -> [Markup] {
+        let source = text.string
+        var result = [Markup]()
+        var foundMath = false
+
+        var currentIndex = source.startIndex
+        var pendingTextStart = source.startIndex
+
+        while currentIndex < source.endIndex {
+            guard canOpenInlineMathDelimiter(in: source, at: currentIndex) else {
+                currentIndex = source.index(after: currentIndex)
+                continue
+            }
+
+            let codeStart = source.index(after: currentIndex)
+            var closingIndex = codeStart
+            var foundClosingDelimiter = false
+
+            while closingIndex < source.endIndex {
+                if canCloseInlineMathDelimiter(in: source, at: closingIndex) {
+                    foundClosingDelimiter = true
+                    break
+                }
+                closingIndex = source.index(after: closingIndex)
+            }
+
+            guard foundClosingDelimiter else {
+                currentIndex = source.index(after: currentIndex)
+                continue
+            }
+
+            if pendingTextStart < currentIndex {
+                result.append(
+                    try! Text(
+                        .text(
+                            parsedRange: slicedRange(in: text, source: source, slice: pendingTextStart..<currentIndex),
+                            string: String(source[pendingTextStart..<currentIndex])
+                        )
+                    )
+                )
+            }
+
+            let afterClosingDelimiter = source.index(after: closingIndex)
+            result.append(
+                try! InlineMath(
+                    .inlineMath(
+                        parsedRange: slicedRange(in: text, source: source, slice: currentIndex..<afterClosingDelimiter),
+                        code: String(source[codeStart..<closingIndex])
+                    )
+                )
+            )
+            foundMath = true
+
+            pendingTextStart = afterClosingDelimiter
+            currentIndex = afterClosingDelimiter
+        }
+
+        guard foundMath else {
+            return [text]
+        }
+
+        if pendingTextStart < source.endIndex {
+            result.append(
+                try! Text(
+                    .text(
+                        parsedRange: slicedRange(in: text, source: source, slice: pendingTextStart..<source.endIndex),
+                        string: String(source[pendingTextStart..<source.endIndex])
+                    )
+                )
+            )
+        }
+
+        return result
+    }
+
+    private func canOpenInlineMathDelimiter(in source: String, at index: String.Index) -> Bool {
+        guard source[index] == "$",
+              !isEscaped(in: source, at: index),
+              isSingleDollarDelimiter(in: source, at: index) else {
+            return false
+        }
+
+        let nextIndex = source.index(after: index)
+        guard nextIndex < source.endIndex else {
+            return false
+        }
+        return !source[nextIndex].isWhitespace
+    }
+
+    private func canCloseInlineMathDelimiter(in source: String, at index: String.Index) -> Bool {
+        guard source[index] == "$",
+              !isEscaped(in: source, at: index),
+              isSingleDollarDelimiter(in: source, at: index),
+              index > source.startIndex else {
+            return false
+        }
+
+        let previousIndex = source.index(before: index)
+        return !source[previousIndex].isWhitespace
+    }
+
+    private func isSingleDollarDelimiter(in source: String, at index: String.Index) -> Bool {
+        if index > source.startIndex {
+            let previousIndex = source.index(before: index)
+            if source[previousIndex] == "$" {
+                return false
+            }
+        }
+
+        let nextIndex = source.index(after: index)
+        if nextIndex < source.endIndex, source[nextIndex] == "$" {
+            return false
+        }
+
+        return true
+    }
+
+    private func isEscaped(in source: String, at index: String.Index) -> Bool {
+        var backslashCount = 0
+        var previousIndex = index
+
+        while previousIndex > source.startIndex {
+            let candidate = source.index(before: previousIndex)
+            guard source[candidate] == "\\" else {
+                break
+            }
+            backslashCount += 1
+            previousIndex = candidate
+        }
+
+        return backslashCount % 2 == 1
+    }
+
+    private func slicedRange(in text: Text, source: String, slice: Range<String.Index>) -> SourceRange? {
+        guard let range = text.range,
+              range.lowerBound.line == range.upperBound.line else {
+            return nil
+        }
+
+        let lowerOffset = source.utf8.distance(from: source.startIndex, to: slice.lowerBound)
+        let upperOffset = source.utf8.distance(from: source.startIndex, to: slice.upperBound)
+
+        let line = range.lowerBound.line
+        let sourceURL = range.lowerBound.source
+        let lowerBound = SourceLocation(line: line, column: range.lowerBound.column + lowerOffset, source: sourceURL)
+        let upperBound = SourceLocation(line: line, column: range.lowerBound.column + upperOffset, source: sourceURL)
+        return lowerBound..<upperBound
+    }
+}

--- a/Sources/Markdown/Parser/ParseOptions.swift
+++ b/Sources/Markdown/Parser/ParseOptions.swift
@@ -30,5 +30,7 @@ public struct ParseOptions: OptionSet, Sendable {
 
     /// Disable including a `data-sourcepos` attribute on all block elements during parsing.
     public static let disableSourcePosOpts = ParseOptions(rawValue: 1 << 4)
-}
 
+    /// Enable parsing of inline and block math equations surrounded by `$` and `$$` delimiters.
+    public static let parseMath = ParseOptions(rawValue: 1 << 5)
+}

--- a/Sources/Markdown/Visitor/MarkupVisitor.swift
+++ b/Sources/Markdown/Visitor/MarkupVisitor.swift
@@ -92,6 +92,14 @@ public protocol MarkupVisitor<Result> {
     mutating func visitHTMLBlock(_ html: HTMLBlock) -> Result
 
     /**
+     Visit a `BlockMath` element and return the result.
+
+     - parameter blockMath: A `BlockMath` element.
+     - returns: The result of the visit.
+     */
+    mutating func visitBlockMath(_ blockMath: BlockMath) -> Result
+
+    /**
      Visit a `ListItem` element and return the result.
 
      - parameter listItem: An `ListItem` element.
@@ -130,6 +138,14 @@ public protocol MarkupVisitor<Result> {
      - returns: The result of the visit.
      */
     mutating func visitBlockDirective(_ blockDirective: BlockDirective) -> Result
+
+    /**
+     Visit a `InlineMath` element and return the result.
+
+     - parameter inlineMath: An `InlineMath` element.
+     - returns: The result of the visit.
+     */
+    mutating func visitInlineMath(_ inlineMath: InlineMath) -> Result
 
     /**
      Visit a `InlineCode` element and return the result.
@@ -344,6 +360,9 @@ extension MarkupVisitor {
     public mutating func visitHTMLBlock(_ html: HTMLBlock) -> Result {
         return defaultVisit(html)
     }
+    public mutating func visitBlockMath(_ blockMath: BlockMath) -> Result {
+        return defaultVisit(blockMath)
+    }
     public mutating func visitListItem(_ listItem: ListItem) -> Result {
         return defaultVisit(listItem)
     }
@@ -358,6 +377,9 @@ extension MarkupVisitor {
     }
     public mutating func visitBlockDirective(_ blockDirective: BlockDirective) -> Result {
         return defaultVisit(blockDirective)
+    }
+    public mutating func visitInlineMath(_ inlineMath: InlineMath) -> Result {
+        return defaultVisit(inlineMath)
     }
     public mutating func visitInlineCode(_ inlineCode: InlineCode) -> Result {
         return defaultVisit(inlineCode)

--- a/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
@@ -89,6 +89,10 @@ public struct HTMLFormatter: MarkupWalker {
         result += "<pre><code\(languageAttr)>\(codeBlock.code)</code></pre>\n"
     }
 
+    public mutating func visitBlockMath(_ blockMath: BlockMath) -> () {
+        result += "<pre><code class=\"language-math\">\(blockMath.code)</code></pre>\n"
+    }
+
     public mutating func visitHeading(_ heading: Heading) -> () {
         result += "<h\(heading.level)>\(heading.plainText)</h\(heading.level)>\n"
     }
@@ -223,6 +227,10 @@ public struct HTMLFormatter: MarkupWalker {
 
     public mutating func visitInlineCode(_ inlineCode: InlineCode) -> () {
         result += "<code>\(inlineCode.code)</code>"
+    }
+
+    public mutating func visitInlineMath(_ inlineMath: InlineMath) -> () {
+        result += "<code class=\"language-math\">\(inlineMath.code)</code>"
     }
 
     public mutating func visitEmphasis(_ emphasis: Emphasis) -> () {

--- a/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
@@ -202,6 +202,15 @@ struct MarkupTreeDumper: MarkupWalker {
         dump(codeBlock, customDescription: "language: \(codeBlock.language ?? "none")\n\(lines)")
     }
 
+    mutating func visitBlockMath(_ blockMath: BlockMath) {
+        if blockMath.code.isEmpty {
+            dump(blockMath)
+            return
+        }
+        let lines = indentLiteralBlock(blockMath.code, from: blockMath, countLines: false)
+        dump(blockMath, customDescription: "\n\(lines)")
+    }
+
     mutating func visitBlockDirective(_ blockDirective: BlockDirective) {
         var argumentsDescription: String
         if !blockDirective.argumentText.segments.isEmpty {
@@ -227,6 +236,10 @@ struct MarkupTreeDumper: MarkupWalker {
 
     mutating func visitInlineCode(_ inlineCode: InlineCode) {
         dump(inlineCode, customDescription: "`\(inlineCode.code)`")
+    }
+
+    mutating func visitInlineMath(_ inlineMath: InlineMath) {
+        dump(inlineMath, customDescription: "$\(inlineMath.code)$")
     }
 
     mutating func visitInlineHTML(_ inlineHTML: InlineHTML) {

--- a/Tests/MarkdownTests/Base/RawMarkupToMarkupTests.swift
+++ b/Tests/MarkdownTests/Base/RawMarkupToMarkupTests.swift
@@ -27,6 +27,11 @@ final class RawMarkupToMarkupTests: XCTestCase {
         XCTAssertThrowsError(try HTMLBlock(.softBreak(parsedRange: nil)))
     }
 
+    func testBlockMath() {
+        XCTAssertNoThrow(try BlockMath(.blockMath(parsedRange: nil, code: "")))
+        XCTAssertThrowsError(try BlockMath(.softBreak(parsedRange: nil)))
+    }
+
     func testHeading() {
         XCTAssertNoThrow(try Heading(.heading(level: 1, parsedRange: nil, [])))
         XCTAssertThrowsError(try Heading(.softBreak(parsedRange: nil)))
@@ -70,6 +75,11 @@ final class RawMarkupToMarkupTests: XCTestCase {
     func testInlineCode() {
         XCTAssertNoThrow(try InlineCode(.inlineCode(parsedRange: nil, code: "")))
         XCTAssertThrowsError(try InlineCode(.softBreak(parsedRange: nil)))
+    }
+
+    func testInlineMath() {
+        XCTAssertNoThrow(try InlineMath(.inlineMath(parsedRange: nil, code: "")))
+        XCTAssertThrowsError(try InlineMath(.softBreak(parsedRange: nil)))
     }
     
     func testInlineHTML() {

--- a/Tests/MarkdownTests/Block Nodes/BlockMathTests.swift
+++ b/Tests/MarkdownTests/Block Nodes/BlockMathTests.swift
@@ -1,0 +1,193 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+@testable import Markdown
+
+final class BlockMathTests: XCTestCase {
+    func testBlockMathCode() {
+        let math = BlockMath("x^2 + y^2")
+        XCTAssertEqual("x^2 + y^2", math.code)
+        XCTAssertEqual(0, math.childCount)
+
+        var editedMath = math
+        editedMath.code = "\\frac{a}{b}"
+        XCTAssertEqual("\\frac{a}{b}", editedMath.code)
+        XCTAssertFalse(math.isIdentical(to: editedMath))
+    }
+
+    func testDetectionFromDelimiters() {
+        let source = """
+        $$
+        x + y
+        $$
+        """
+
+        do { // option on
+            let document = Document(parsing: source, options: .parseMath)
+            XCTAssertEqual(1, document.childCount)
+            guard let blockMath = document.child(at: 0) as? BlockMath else {
+                XCTFail("Expected BlockMath")
+                return
+            }
+            XCTAssertEqual("x + y", blockMath.code)
+        }
+
+        do { // option off
+            let document = Document(parsing: source)
+            XCTAssertTrue(document.child(at: 0) is Paragraph)
+        }
+    }
+
+    func testSingleLineDetectionFromDelimiters() {
+        let source = "$$x + y$$"
+        let document = Document(parsing: source, options: .parseMath)
+        guard let blockMath = document.child(at: 0) as? BlockMath else {
+            XCTFail("Expected BlockMath")
+            return
+        }
+        XCTAssertEqual("x + y", blockMath.code)
+    }
+
+    func testDetectionInsideBlockQuote() {
+        let source = """
+        > $$
+        > x + y
+        > $$
+        """
+        let document = Document(parsing: source, options: .parseMath)
+        guard let quote = document.child(at: 0) as? BlockQuote else {
+            XCTFail("Expected BlockQuote")
+            return
+        }
+        XCTAssertTrue(quote.child(at: 0) is BlockMath)
+    }
+
+    func testNoDetectionForInlineDoubleDollars() {
+        let source = "before $$x + y$$ after"
+        let document = Document(parsing: source, options: .parseMath)
+        guard let paragraph = document.child(at: 0) as? Paragraph else {
+            XCTFail("Expected paragraph")
+            return
+        }
+        XCTAssertFalse(paragraph.children.contains(where: { $0 is InlineMath }))
+        XCTAssertFalse(paragraph.children.contains(where: { $0 is BlockMath }))
+    }
+
+    func testNoDetectionWhenClosingDelimiterHasTrailingText() {
+        let source = """
+        $$
+        x + y
+        $$ trailing
+        """
+        let document = Document(parsing: source, options: .parseMath)
+        XCTAssertTrue(document.child(at: 0) is Paragraph)
+    }
+
+    func testNoDetectionForMixedInlineChildren() {
+        let source = "$$ *x + y* $$"
+        let document = Document(parsing: source, options: .parseMath)
+        XCTAssertTrue(document.child(at: 0) is Paragraph)
+    }
+
+    func testNoDetectionWithBlankLinesInsideBlock() {
+        let source = """
+        $$
+        x
+
+        y
+        $$
+        """
+        let document = Document(parsing: source, options: .parseMath)
+        XCTAssertTrue(document.child(at: 0) is Paragraph)
+    }
+
+    func testNoDetectionForUnmatchedOpeningDelimiter() {
+        let source = """
+        $$
+        x + y
+        """
+        let document = Document(parsing: source, options: .parseMath)
+        XCTAssertTrue(document.child(at: 0) is Paragraph)
+    }
+
+    func testNoDetectionForUnmatchedClosingDelimiter() {
+        let source = """
+        x + y
+        $$
+        """
+        let document = Document(parsing: source, options: .parseMath)
+        XCTAssertTrue(document.child(at: 0) is Paragraph)
+    }
+
+    func testNoDetectionForTripleDollarDelimiters() {
+        let source = """
+        $$$
+        x + y
+        $$$
+        """
+        let document = Document(parsing: source, options: .parseMath)
+        XCTAssertTrue(document.child(at: 0) is Paragraph)
+    }
+
+    func testDetectionWithWhitespaceAroundDelimiterLines() {
+        let source = """
+          $$  
+        x + y
+         $$
+        """
+        let document = Document(parsing: source, options: .parseMath)
+        guard let blockMath = document.child(at: 0) as? BlockMath else {
+            XCTFail("Expected BlockMath")
+            return
+        }
+        XCTAssertEqual("x + y", blockMath.code)
+    }
+
+    func testFormatAndHTML() {
+        let document = Document([BlockMath("x + y")])
+        XCTAssertEqual(
+            """
+            $$
+            x + y
+            $$
+            """,
+            document.format()
+        )
+        XCTAssertEqual(
+            "<pre><code class=\"language-math\">x + y</code></pre>\n",
+            HTMLFormatter.format(document)
+        )
+    }
+
+    func testRangePreservedAfterParsing() {
+        let source = URL(string: "https://swift.org/math.md")
+        let document = Document(
+            parsing: """
+            $$
+            x + y
+            $$
+            """,
+            source: source,
+            options: .parseMath
+        )
+        guard let blockMath = document.child(at: 0) as? BlockMath else {
+            XCTFail("Expected BlockMath")
+            return
+        }
+
+        XCTAssertEqual(1, blockMath.range?.lowerBound.line)
+        XCTAssertEqual(1, blockMath.range?.lowerBound.column)
+        XCTAssertEqual(3, blockMath.range?.upperBound.line)
+        XCTAssertEqual(3, blockMath.range?.upperBound.column)
+        XCTAssertEqual(source, blockMath.range?.lowerBound.source)
+        XCTAssertEqual(source, blockMath.range?.upperBound.source)
+    }
+}

--- a/Tests/MarkdownTests/Inline Nodes/InlineMathTests.swift
+++ b/Tests/MarkdownTests/Inline Nodes/InlineMathTests.swift
@@ -1,0 +1,209 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+@testable import Markdown
+
+final class InlineMathTests: XCTestCase {
+    func testInlineMathCode() {
+        let math = InlineMath("x^2 + y^2")
+        XCTAssertEqual("x^2 + y^2", math.code)
+        XCTAssertEqual(0, math.childCount)
+
+        var editedMath = math
+        editedMath.code = "\\frac{a}{b}"
+        XCTAssertEqual("\\frac{a}{b}", editedMath.code)
+        XCTAssertFalse(math.isIdentical(to: editedMath))
+    }
+
+    func testDetectionFromDelimiters() {
+        let source = "The sum is $x + y$."
+
+        do { // option on
+            let document = Document(parsing: source, options: .parseMath)
+            guard let paragraph = document.child(at: 0) as? Paragraph else {
+                XCTFail("Expected paragraph")
+                return
+            }
+            XCTAssertEqual(3, paragraph.childCount)
+            guard let inlineMath = paragraph.child(at: 1) as? InlineMath else {
+                XCTFail("Expected InlineMath")
+                return
+            }
+            XCTAssertEqual("x + y", inlineMath.code)
+        }
+
+        do { // option off
+            let document = Document(parsing: source)
+            guard let paragraph = document.child(at: 0) as? Paragraph else {
+                XCTFail("Expected paragraph")
+                return
+            }
+            XCTAssertTrue(paragraph.children.allSatisfy { !($0 is InlineMath) })
+        }
+    }
+
+    func testNoDetectionForCurrencyStyleDollars() {
+        let source = "It costs $5 and $10."
+        let document = Document(parsing: source, options: .parseMath)
+        guard let paragraph = document.child(at: 0) as? Paragraph else {
+            XCTFail("Expected paragraph")
+            return
+        }
+        XCTAssertTrue(paragraph.children.allSatisfy { !($0 is InlineMath) })
+    }
+
+    func testEscapedDelimitersAreNotParsed() {
+        let source = #"Escaped \\$x$ and $y\\$ stay text."#
+        let document = Document(parsing: source, options: .parseMath)
+        guard let paragraph = document.child(at: 0) as? Paragraph else {
+            XCTFail("Expected paragraph")
+            return
+        }
+        XCTAssertTrue(paragraph.children.allSatisfy { !($0 is InlineMath) })
+    }
+
+    func testMultipleInlineMathSegments() {
+        let source = "A $x$ and $y$."
+        let document = Document(parsing: source, options: .parseMath)
+        guard let paragraph = document.child(at: 0) as? Paragraph else {
+            XCTFail("Expected paragraph")
+            return
+        }
+        XCTAssertEqual(5, paragraph.childCount)
+        XCTAssertEqual("x", (paragraph.child(at: 1) as? InlineMath)?.code)
+        XCTAssertEqual("y", (paragraph.child(at: 3) as? InlineMath)?.code)
+    }
+
+    func testNoDetectionWhenWhitespaceTouchesDelimiters() {
+        let source = "$ x$ and $y $"
+        let document = Document(parsing: source, options: .parseMath)
+        guard let paragraph = document.child(at: 0) as? Paragraph else {
+            XCTFail("Expected paragraph")
+            return
+        }
+        XCTAssertTrue(paragraph.children.allSatisfy { !($0 is InlineMath) })
+    }
+
+    func testNoDetectionAcrossSoftBreaks() {
+        let source = """
+        A $x
+        + y$
+        """
+        let document = Document(parsing: source, options: .parseMath)
+        guard let paragraph = document.child(at: 0) as? Paragraph else {
+            XCTFail("Expected paragraph")
+            return
+        }
+        XCTAssertTrue(paragraph.children.allSatisfy { !($0 is InlineMath) })
+    }
+
+    func testNoDetectionForUnmatchedOpeningDelimiter() {
+        let source = "A $x + y."
+        let document = Document(parsing: source, options: .parseMath)
+        guard let paragraph = document.child(at: 0) as? Paragraph else {
+            XCTFail("Expected paragraph")
+            return
+        }
+        XCTAssertTrue(paragraph.children.allSatisfy { !($0 is InlineMath) })
+    }
+
+    func testNoDetectionForUnmatchedClosingDelimiter() {
+        let source = "A x + y$."
+        let document = Document(parsing: source, options: .parseMath)
+        guard let paragraph = document.child(at: 0) as? Paragraph else {
+            XCTFail("Expected paragraph")
+            return
+        }
+        XCTAssertTrue(paragraph.children.allSatisfy { !($0 is InlineMath) })
+    }
+
+    func testAdjacentDelimitersFormSingleInlineMathSpan() {
+        let source = "$x$$y$"
+        let document = Document(parsing: source, options: .parseMath)
+        guard let paragraph = document.child(at: 0) as? Paragraph else {
+            XCTFail("Expected paragraph")
+            return
+        }
+
+        XCTAssertEqual(1, paragraph.childCount)
+        XCTAssertEqual("x$$y", (paragraph.child(at: 0) as? InlineMath)?.code)
+    }
+
+    func testDetectionInsideEmphasisButNotInsideInlineCode() {
+        let source = "*a $x$* and `$y$`"
+        let document = Document(parsing: source, options: .parseMath)
+        guard let paragraph = document.child(at: 0) as? Paragraph else {
+            XCTFail("Expected paragraph")
+            return
+        }
+
+        guard let emphasis = paragraph.child(at: 0) as? Emphasis else {
+            XCTFail("Expected Emphasis")
+            return
+        }
+        XCTAssertTrue(emphasis.children.contains(where: { $0 is InlineMath }))
+
+        guard let inlineCode = paragraph.children.first(where: { $0 is InlineCode }) as? InlineCode else {
+            XCTFail("Expected InlineCode")
+            return
+        }
+        XCTAssertEqual("$y$", inlineCode.code)
+    }
+
+    func testFormatAndHTML() {
+        let document = Document([Paragraph(Text("A "), InlineMath("x + y"), Text(" B"))])
+        XCTAssertEqual("A $x + y$ B", document.format())
+        XCTAssertEqual(
+            "<p>A <code class=\"language-math\">x + y</code> B</p>\n",
+            HTMLFormatter.format(document)
+        )
+    }
+
+    func testRangePreservedAfterParsing() {
+        let source = URL(string: "https://swift.org/math.md")
+        let document = Document(
+            parsing: "$x$",
+            source: source,
+            options: .parseMath
+        )
+        guard let paragraph = document.child(at: 0) as? Paragraph,
+              let inlineMath = paragraph.child(at: 0) as? InlineMath else {
+            XCTFail("Expected InlineMath")
+            return
+        }
+
+        XCTAssertEqual(1, inlineMath.range?.lowerBound.line)
+        XCTAssertEqual(1, inlineMath.range?.lowerBound.column)
+        XCTAssertEqual(1, inlineMath.range?.upperBound.line)
+        XCTAssertEqual(4, inlineMath.range?.upperBound.column)
+        XCTAssertEqual(source, inlineMath.range?.lowerBound.source)
+        XCTAssertEqual(source, inlineMath.range?.upperBound.source)
+    }
+
+    func testRangePreservedWithinLargerText() {
+        let source = URL(string: "https://swift.org/math.md")
+        let document = Document(
+            parsing: "A $xy$ B",
+            source: source,
+            options: .parseMath
+        )
+        guard let paragraph = document.child(at: 0) as? Paragraph,
+              let inlineMath = paragraph.child(at: 1) as? InlineMath else {
+            XCTFail("Expected InlineMath")
+            return
+        }
+
+        XCTAssertEqual(1, inlineMath.range?.lowerBound.line)
+        XCTAssertEqual(3, inlineMath.range?.lowerBound.column)
+        XCTAssertEqual(1, inlineMath.range?.upperBound.line)
+        XCTAssertEqual(7, inlineMath.range?.upperBound.column)
+    }
+}


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

_Implement a LaTex block parsing so that users of the library can actually render LaTex blocks in their own app ._

## Dependencies

_None._

## Testing

_Unit tests included._

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
