### PR TITLE
resolves #93 - allows backticks in code voice

### DIFF
--- a/Sources/Markdown/Parser/CommonMarkConverter.swift
+++ b/Sources/Markdown/Parser/CommonMarkConverter.swift
@@ -403,7 +403,8 @@ struct MarkupParser {
         let parsedRange = state.range(state.node)
         let literalContent = getLiteralContent(node: state.node)
         if state.options.contains(.parseSymbolLinks),
-           cmark_node_get_backtick_count(state.node) > 1 {
+           cmark_node_get_backtick_count(state.node) == 2,
+           !literalContent.contains("`") {
             return MarkupConversion(state: state.next(), result: .symbolLink(parsedRange: parsedRange, destination: literalContent))
         } else {
             return MarkupConversion(state: state.next(), result: .inlineCode(parsedRange: parsedRange, code: literalContent))

--- a/Sources/Markdown/Parser/CommonMarkConverter.swift
+++ b/Sources/Markdown/Parser/CommonMarkConverter.swift
@@ -403,7 +403,7 @@ struct MarkupParser {
         let parsedRange = state.range(state.node)
         let literalContent = getLiteralContent(node: state.node)
         if state.options.contains(.parseSymbolLinks),
-           cmark_node_get_backtick_count(state.node) == 2,
+           cmark_node_get_backtick_count(state.node) > 1,
            !literalContent.contains("`") {
             return MarkupConversion(state: state.next(), result: .symbolLink(parsedRange: parsedRange, destination: literalContent))
         } else {

--- a/Tests/MarkdownTests/Parsing/BacktickTests.swift
+++ b/Tests/MarkdownTests/Parsing/BacktickTests.swift
@@ -46,4 +46,65 @@ class BacktickTests: XCTestCase {
         """
         XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
     }
+
+    // MARK: - Backtick in code voice (rdar://116587933, https://github.com/swiftlang/swift-markdown/issues/93)
+
+    func testBacktickInCodeVoiceWithDoubleBacktickDelimiters() {
+        // CommonMark: `` ` `` produces a code span containing a single backtick.
+        // With parseSymbolLinks enabled, this should remain InlineCode, not become a SymbolLink.
+        let source = "Use `` ` `` to delimit"
+        let document = Document(parsing: source, options: .parseSymbolLinks)
+        let expectedDump = """
+        Document @1:1-1:23
+        └─ Paragraph @1:1-1:23
+           ├─ Text @1:1-1:5 "Use "
+           ├─ InlineCode @1:5-1:12 ```
+           └─ Text @1:12-1:23 " to delimit"
+        """
+        XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
+    }
+
+    func testBacktickInCodeVoiceWithTripleBacktickDelimiters() {
+        // CommonMark: ``` ` ``` produces a code span containing a single backtick.
+        // With parseSymbolLinks enabled, this should remain InlineCode, not become a SymbolLink.
+        let source = "Use ``` ` ``` to delimit"
+        let document = Document(parsing: source, options: .parseSymbolLinks)
+        let expectedDump = """
+        Document @1:1-1:25
+        └─ Paragraph @1:1-1:25
+           ├─ Text @1:1-1:5 "Use "
+           ├─ InlineCode @1:5-1:14 ```
+           └─ Text @1:14-1:25 " to delimit"
+        """
+        XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
+    }
+
+    func testDoubleBacktickSymbolLinkStillWorks() {
+        // Regression guard: ``symbol`` with parseSymbolLinks should still be a SymbolLink.
+        let source = "See ``foo()`` for details"
+        let document = Document(parsing: source, options: .parseSymbolLinks)
+        let expectedDump = """
+        Document @1:1-1:26
+        └─ Paragraph @1:1-1:26
+           ├─ Text @1:1-1:5 "See "
+           ├─ SymbolLink @1:5-1:14 destination: foo()
+           └─ Text @1:14-1:26 " for details"
+        """
+        XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
+    }
+
+    func testMultipleBackticksInCodeVoice() {
+        // CommonMark: ``` `` ``` produces a code span containing two backticks.
+        // With parseSymbolLinks enabled, this should remain InlineCode, not become a SymbolLink.
+        let source = "Use ``` `` ``` in code"
+        let document = Document(parsing: source, options: .parseSymbolLinks)
+        let expectedDump = """
+        Document @1:1-1:23
+        └─ Paragraph @1:1-1:23
+           ├─ Text @1:1-1:5 "Use "
+           ├─ InlineCode @1:5-1:15 ````
+           └─ Text @1:15-1:23 " in code"
+        """
+        XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
+    }
 }


### PR DESCRIPTION
resolves #93 - which allows backticks to appear in "code voice", used in content within https://github.com/swiftlang/swift-book (see https://github.com/swiftlang/swift-book/issues/71 for some detail in that repo)

This fix leans a concept that symbols when done with backticks, will always use exactly 2 backticks - and adds a smidge of a double check to make sure that the symbol content itself doesn't contain a backtick, which *I think* is a safe bet.