### PR TITLE
resolves #168 - Fix Strikethrough.plainText to preserve original tilde count

### DIFF
--- a/Sources/Markdown/Inline Nodes/Inline Containers/Strikethrough.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/Strikethrough.swift
@@ -44,7 +44,24 @@ public extension Strikethrough {
         let childrenPlainText = children.compactMap {
             return ($0 as? InlineMarkup)?.plainText
         }.joined()
-        return "~\(childrenPlainText)~"
+        let tilde = String(repeating: "~", count: tildeCount)
+        return "\(tilde)\(childrenPlainText)\(tilde)"
+    }
+
+    /// The number of tilde characters (`~`) used as delimiters for this strikethrough.
+    ///
+    /// When parsed from source, this reflects whether the original markup used
+    /// single (`~`) or double (`~~`) tildes. For programmatically constructed
+    /// instances, this defaults to 1.
+    var tildeCount: Int {
+        guard let strikethroughStart = range?.lowerBound,
+              childCount > 0,
+              let childStart = child(at: 0)?.range?.lowerBound,
+              strikethroughStart.line == childStart.line else {
+            return 1
+        }
+        let count = childStart.column - strikethroughStart.column
+        return count > 0 ? count : 1
     }
 
     // MARK: Visitation

--- a/Tests/MarkdownTests/Base/PlainTextConvertibleMarkupTests.swift
+++ b/Tests/MarkdownTests/Base/PlainTextConvertibleMarkupTests.swift
@@ -72,4 +72,24 @@ final class PlainTextConvertibleMarkupTests: XCTestCase {
         let text = Text("OK")
         XCTAssertEqual("OK", text.plainText)
     }
+
+    func testStrikethroughSingleTilde() {
+        let document = Document(parsing: "~struck~")
+        let strikethrough = document.child(at: 0)?.child(at: 0) as! Strikethrough
+        XCTAssertEqual(1, strikethrough.tildeCount)
+        XCTAssertEqual("~struck~", strikethrough.plainText)
+    }
+
+    func testStrikethroughDoubleTilde() {
+        let document = Document(parsing: "~~struck~~")
+        let strikethrough = document.child(at: 0)?.child(at: 0) as! Strikethrough
+        XCTAssertEqual(2, strikethrough.tildeCount)
+        XCTAssertEqual("~~struck~~", strikethrough.plainText)
+    }
+
+    func testStrikethroughProgrammatic() {
+        let strikethrough = Strikethrough(Text("struck"))
+        XCTAssertEqual(1, strikethrough.tildeCount)
+        XCTAssertEqual("~struck~", strikethrough.plainText)
+    }
 }


### PR DESCRIPTION
## Summary

Discussion in Issue: https://github.com/swiftlang/swift-markdown/issues/168

`Strikethrough` `plainText` computed property always returned single tildes (`~text~`) even when the source used double tildes (`~~text~~`) because it simply reconstructs the original text assuming a single tilde was used:

```
return "~\(childrenPlainText)~"
``` 

This change adds a tildeCount computed property that derives the delimiter count from source ranges, and uses it in `plainText` to return the correct representation.  

