### PR TITLE
Add compatibility for Embedded Swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ let cmarkPackageName = ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DE
 
 let package = Package(
     name: "swift-markdown",
+    platforms: [.macOS(.v10_15)],
     products: [
         .library(
             name: "Markdown",

--- a/Sources/Markdown/Base/Document.swift
+++ b/Sources/Markdown/Base/Document.swift
@@ -8,7 +8,9 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(Foundation)
 import Foundation
+#endif
 
 /// A markup element representing the top level of a whole document.
 ///
@@ -41,7 +43,7 @@ public extension Document {
     /// - parameter options: options for parsing Markdown text.
     /// - parameter source: an explicit source URL from which the input `string` came for marking source locations.
     ///   This need not be a file URL.
-    init(parsing string: String, source: URL? = nil, options: ParseOptions = []) {
+    init(parsing string: String, source: SourceIdentifier? = nil, options: ParseOptions = []) {
         if options.contains(.parseBlockDirectives) {
             self = BlockDirectiveParser.parse(string, source: source,
                                               options: options)
@@ -50,6 +52,7 @@ public extension Document {
         }
     }
 
+    #if canImport(Foundation)
     /// Parse a file's contents into a `Document`.
     ///
     /// - parameter file: a file URL from which to load Markdown text to parse.
@@ -63,6 +66,7 @@ public extension Document {
             self = MarkupParser.parseString(string, source: file, options: options)
         }
     }
+    #endif
 
     /// Create a document from a sequence of block markup elements.
     init(_ children: some Sequence<BlockMarkup>) {

--- a/Sources/Markdown/Base/Document.swift
+++ b/Sources/Markdown/Base/Document.swift
@@ -81,7 +81,9 @@ public extension Document {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitDocument(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Base/Document.swift
+++ b/Sources/Markdown/Base/Document.swift
@@ -20,7 +20,7 @@ public struct Document: Markup, BasicBlockContainer {
 
     init(_ raw: RawMarkup) throws {
         guard case .document = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: Document.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "Document")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -74,7 +74,7 @@ public extension Document {
     }
 
     init(_ children: some Sequence<BlockMarkup>, inheritSourceRange: Bool) {
-        let rawChildren = children.map { $0.raw.markup }
+        let rawChildren = children.map { $0._data.raw.markup }
         let parsedRange = inheritSourceRange ? rawChildren.parsedRange : nil
         try! self.init(.document(parsedRange: parsedRange, rawChildren))
     }

--- a/Sources/Markdown/Base/Markup.swift
+++ b/Sources/Markdown/Base/Markup.swift
@@ -122,7 +122,7 @@ extension Markup {
     ///
     /// - Complexity: `O(1)`
     var subtreeCount: Int {
-        return raw.markup.header.subtreeCount
+        return raw.markup.subtreeCount
     }
 
     /// Return this element without ``SoftBreak`` elements, or `nil` if this
@@ -178,7 +178,7 @@ extension Markup {
     ///
     /// - Complexity: `O(1)`
     public var childCount: Int {
-        return raw.markup.header.childCount
+        return raw.markup.childCount
     }
 
     /// `true` if this element has no children.

--- a/Sources/Markdown/Base/Markup.swift
+++ b/Sources/Markdown/Base/Markup.swift
@@ -100,6 +100,30 @@ public protocol Markup {
     /// The data backing the markup element.
     /// > Note: This property is an implementation detail; do not use it directly.
     var _data: _MarkupData { get set }
+
+    /// The parent of this element, or `nil` if this is a root.
+    var parent: Markup? { get }
+
+    /// The number of this element's children.
+    var childCount: Int { get }
+
+    /// `true` if this element has no children.
+    var isEmpty: Bool { get }
+
+    /// The children of the element.
+    var children: MarkupChildren { get }
+
+    /// The index in the parent's children.
+    var indexInParent: Int { get }
+
+    /// The text range where this element was parsed, or `nil` if it was constructed outside of parsing.
+    var range: SourceRange? { get }
+
+    /// The child at the given position if it is within the bounds of `children.indices`.
+    func child(at position: Int) -> Markup?
+
+    /// Returns a copy of this element with the given children instead.
+    func withUncheckedChildren(_ newChildren: [Markup]) -> Markup
 }
 
 // MARK: - Private API
@@ -139,7 +163,14 @@ extension Markup {
     /// - parameter newChildren: A sequence of children to use instead of the current children.
     /// - warning: This does not check for compatibility. This API should only be used when the type of the children are already known to be the right kind.
     public func withUncheckedChildren<Children: Sequence>(_ newChildren: Children) -> Markup where Children.Element == Markup {
-        let newRaw = raw.markup.withChildren(newChildren.map { $0.raw.markup })
+        let newRaw = raw.markup.withChildren(newChildren.map { $0._data.raw.markup })
+        return makeMarkup(_data.replacingSelf(newRaw))
+    }
+
+    /// Default implementation of the `Markup` protocol requirement —
+    /// non-generic overload that delegates to the generic version.
+    public func withUncheckedChildren(_ newChildren: [Markup]) -> Markup {
+        let newRaw = raw.markup.withChildren(newChildren.map { $0._data.raw.markup })
         return makeMarkup(_data.replacingSelf(newRaw))
     }
 }

--- a/Sources/Markdown/Base/Markup.swift
+++ b/Sources/Markdown/Base/Markup.swift
@@ -89,11 +89,13 @@ func makeMarkup(_ data: _MarkupData) -> Markup {
 /// > Note: All supported markup elements are already implemented in the framework.
 /// Use this protocol only as a generic constraint.
 public protocol Markup {
+    #if !hasFeature(Embedded)
     /// Accept a `MarkupVisitor` and call the specific visitation method for this element.
     ///
     /// - parameter visitor: The `MarkupVisitor` visiting the element.
     /// - returns: The result of the visit.
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result
+    #endif
 
     /// The data backing the markup element.
     /// > Note: This property is an implementation detail; do not use it directly.

--- a/Sources/Markdown/Base/MarkupChildren.swift
+++ b/Sources/Markdown/Base/MarkupChildren.swift
@@ -15,46 +15,47 @@
 /// cached and calculated on demand.
 public struct MarkupChildren: Sequence {
     public struct Iterator: IteratorProtocol {
-        let parent: Markup
+        let parentData: _MarkupData
         var childMetadata: MarkupMetadata
 
-        init(_ parent: Markup) {
-            self.parent = parent
-            self.childMetadata = parent.raw.metadata.firstChild()
+        init(_ parentData: _MarkupData) {
+            self.parentData = parentData
+            self.childMetadata = parentData.raw.metadata.firstChild()
         }
 
         public mutating func next() -> Markup? {
             let index = childMetadata.indexInParent
-            guard index < parent.childCount else {
+            guard index < parentData.raw.markup.childCount else {
                 return nil
             }
-            let rawChild = parent.raw.markup.child(at: index)
+            let rawChild = parentData.raw.markup.child(at: index)
             let absoluteRawChild = AbsoluteRawMarkup(markup: rawChild, metadata: childMetadata)
+            let parent = makeMarkup(parentData)
             let data = _MarkupData(absoluteRawChild, parent: parent)
             childMetadata = childMetadata.nextSibling(from: rawChild)
             return makeMarkup(data)
         }
     }
 
-    /// The parent whose children this sequence represents.
-    let parent: Markup
+    /// The data of the parent whose children this sequence represents.
+    let parentData: _MarkupData
 
     /// Create a lazy sequence of an element's children.
     ///
     /// - parameter parent: the parent whose children this sequence represents.
     init(_ parent: Markup) {
-        self.parent = parent
+        self.parentData = parent._data
     }
 
     // MARK: Sequence
 
     public func makeIterator() -> Iterator {
-        return Iterator(parent)
+        return Iterator(parentData)
     }
 
     /// A reversed view of the element's children.
     public func reversed() -> ReversedMarkupChildren {
-        return ReversedMarkupChildren(parent)
+        return ReversedMarkupChildren(parentData)
     }
 }
 
@@ -65,18 +66,15 @@ public struct MarkupChildren: Sequence {
 /// cached and calculated on demand.
 public struct ReversedMarkupChildren: Sequence {
     public struct Iterator: IteratorProtocol {
-        /// The parent whose children this sequence represents.
-        ///
-        /// This is also necessary for creating an "absolute" child from
-        /// parentless ``RawMarkup``.
-        let parent: Markup
+        /// The data of the parent whose children this sequence represents.
+        let parentData: _MarkupData
 
         /// The metadata to use when creating an absolute child element.
         var childMetadata: MarkupMetadata
 
-        init(_ parent: Markup) {
-            self.parent = parent
-            self.childMetadata = parent.raw.metadata.lastChildMetadata(of: parent.raw.markup)
+        init(_ parentData: _MarkupData) {
+            self.parentData = parentData
+            self.childMetadata = parentData.raw.metadata.lastChildMetadata(of: parentData.raw.markup)
         }
 
         public mutating func next() -> Markup? {
@@ -84,26 +82,31 @@ public struct ReversedMarkupChildren: Sequence {
             guard index >= 0 else {
                 return nil
             }
-            let rawChild = parent.raw.markup.child(at: index)
+            let rawChild = parentData.raw.markup.child(at: index)
             let absoluteRawChild = AbsoluteRawMarkup(markup: rawChild, metadata: childMetadata)
+            let parent = makeMarkup(parentData)
             let data = _MarkupData(absoluteRawChild, parent: parent)
             childMetadata = childMetadata.previousSibling(from: rawChild)
             return makeMarkup(data)
         }
     }
 
-    /// The parent whose children this sequence represents.
-    let parent: Markup
+    /// The data of the parent whose children this sequence represents.
+    let parentData: _MarkupData
 
     /// Create a reversed view of an element's children.
     ///
     /// - parameter parent: The parent whose children this sequence will represent.
     init(_ parent: Markup) {
-        self.parent = parent
+        self.parentData = parent._data
+    }
+
+    init(_ parentData: _MarkupData) {
+        self.parentData = parentData
     }
 
     // MARK: Sequence
     public func makeIterator() -> Iterator {
-        return Iterator(parent)
+        return Iterator(parentData)
     }
 }

--- a/Sources/Markdown/Base/RawMarkup.swift
+++ b/Sources/Markdown/Base/RawMarkup.swift
@@ -133,7 +133,7 @@ final class RawMarkup {
     var children: some Sequence<RawMarkup> { _children }
 
     enum Error: Swift.Error, CustomStringConvertible {
-        case concreteConversionError(from: RawMarkup, to: Markup.Type)
+        case concreteConversionError(from: RawMarkup, to: String)
         var description: String {
             switch self {
             case let .concreteConversionError(raw, to: type):
@@ -145,7 +145,7 @@ final class RawMarkup {
 #else
 final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
     enum Error: LocalizedError {
-        case concreteConversionError(from: RawMarkup, to: Markup.Type)
+        case concreteConversionError(from: RawMarkup, to: String)
         var errorDescription: String? {
             switch self {
             case let .concreteConversionError(raw, to: type):

--- a/Sources/Markdown/Base/RawMarkup.swift
+++ b/Sources/Markdown/Base/RawMarkup.swift
@@ -8,7 +8,9 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(Foundation)
 import Foundation
+#endif
 
 /// The data specific to a kind of markup element.
 ///
@@ -93,6 +95,54 @@ public struct RawMarkupHeader {
     var parsedRange: SourceRange?
 }
 
+#if hasFeature(Embedded)
+/// Embedded Swift variant: uses a plain array for children storage instead of
+/// tail-allocated ManagedBuffer elements, avoiding the self-referential generic
+/// `ManagedBuffer<RawMarkupHeader, RawMarkup>` that causes the compiler's
+/// generic specializer to hang (https://github.com/swiftlang/swift/pull/88296).
+final class RawMarkup {
+    var header: RawMarkupHeader
+    private let _children: [RawMarkup]
+
+    fileprivate static func create(data: RawMarkupData, parsedRange: SourceRange?, children: [RawMarkup]) -> RawMarkup {
+        return RawMarkup(
+            header: RawMarkupHeader(data: data,
+                                    childCount: children.count,
+                                    subtreeCount: 1 + children.subtreeCount,
+                                    parsedRange: parsedRange),
+            children: children)
+    }
+
+    private init(header: RawMarkupHeader, children: [RawMarkup]) {
+        self.header = header
+        self._children = children
+    }
+
+    var data: RawMarkupData { header.data }
+    var childCount: Int { header.childCount }
+    var subtreeCount: Int { header.subtreeCount }
+    var parsedRange: SourceRange? { header.parsedRange }
+
+    func child(at index: Int) -> RawMarkup {
+        precondition(index < header.childCount)
+        return _children[index]
+    }
+
+    func copyChildren() -> [RawMarkup] { _children }
+
+    var children: some Sequence<RawMarkup> { _children }
+
+    enum Error: Swift.Error, CustomStringConvertible {
+        case concreteConversionError(from: RawMarkup, to: Markup.Type)
+        var description: String {
+            switch self {
+            case let .concreteConversionError(raw, to: type):
+                return "Can't wrap a \(raw.data) in a \(type)"
+            }
+        }
+    }
+}
+#else
 final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
     enum Error: LocalizedError {
         case concreteConversionError(from: RawMarkup, to: Markup.Type)
@@ -103,7 +153,8 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
             }
         }
     }
-    private static func create(data: RawMarkupData, parsedRange: SourceRange?, children: [RawMarkup]) -> RawMarkup {
+
+    fileprivate static func create(data: RawMarkupData, parsedRange: SourceRange?, children: [RawMarkup]) -> RawMarkup {
         let buffer = self.create(minimumCapacity: children.count) { _ in
             RawMarkupHeader(data: data,
                             childCount: children.count,
@@ -155,10 +206,8 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
     }
 
     /// The children of this element.
-    var children: AnySequence<RawMarkup> {
-        return AnySequence((0..<childCount).lazy.map { Int -> RawMarkup in
-            self.child(at: 0)
-        })
+    var children: some Sequence<RawMarkup> {
+        return (0..<childCount).lazy.map { _ in self.child(at: 0) }
     }
 
     deinit {
@@ -166,6 +215,12 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
             $0.deinitialize(count: header.childCount)
         }
     }
+}
+#endif
+
+// MARK: - Shared API
+
+extension RawMarkup {
 
     // MARK: Aspects
 
@@ -174,11 +229,11 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
         if self === other {
             return true
         }
-        guard self.header.childCount == other.header.childCount,
-            self.header.data == other.header.data else {
+        guard self.childCount == other.childCount,
+            self.data == other.data else {
                 return false
         }
-        for i in 0..<header.childCount {
+        for i in 0..<childCount {
             guard self.child(at: i).hasSameStructure(as: other.child(at: i)) else {
                 return false
             }
@@ -197,16 +252,16 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
 
         let parsedRange: SourceRange?
         if preserveRange {
-            parsedRange = header.parsedRange
+            parsedRange = self.parsedRange
         } else {
-            parsedRange = newChild.header.parsedRange
+            parsedRange = newChild.parsedRange
         }
 
-        return RawMarkup.create(data: header.data, parsedRange: parsedRange, children: newChildren)
+        return RawMarkup.create(data: data, parsedRange: parsedRange, children: newChildren)
     }
 
     func withChildren<Children: Collection>(_ newChildren: Children) -> RawMarkup where Children.Element == RawMarkup {
-        return .create(data: header.data, parsedRange: header.parsedRange, children: Array(newChildren))
+        return .create(data: data, parsedRange: parsedRange, children: Array(newChildren))
     }
 
     // MARK: Block Creation

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/BlockDirective.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/BlockDirective.swift
@@ -67,7 +67,7 @@ public struct BlockDirective: BlockContainer {
 
     init(_ raw: RawMarkup) throws {
         guard case .blockDirective = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: BlockDirective.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "BlockDirective")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -92,7 +92,7 @@ public extension BlockDirective {
                              children: Children) where Children.Element == BlockMarkup {
         let argumentSegments = argumentText?.split(
             omittingEmptySubsequences: false,
-            whereSeparator: \.isNewline
+            whereSeparator: { $0.isNewline }
         ).map { lineText -> DirectiveArgumentText.LineSegment in
             let untrimmedText = String(lineText)
             return DirectiveArgumentText.LineSegment(untrimmedText: untrimmedText,
@@ -102,7 +102,7 @@ public extension BlockDirective {
                                        nameLocation: nil,
                                        argumentText: DirectiveArgumentText(segments: argumentSegments),
                                        parsedRange: nil,
-                                       children.map { $0.raw.markup }))
+                                       children.map { $0._data.raw.markup }))
     }
 
     /// Create a block directive.

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/BlockDirective.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/BlockDirective.swift
@@ -174,7 +174,9 @@ public extension BlockDirective {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitBlockDirective(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/BlockQuote.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/BlockQuote.swift
@@ -41,7 +41,9 @@ public extension BlockQuote {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitBlockQuote(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/BlockQuote.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/BlockQuote.swift
@@ -13,7 +13,7 @@ public struct BlockQuote: BlockMarkup, BasicBlockContainer {
     public var _data: _MarkupData
     init(_ raw: RawMarkup) throws {
         guard case .blockQuote = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: BlockQuote.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "BlockQuote")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -34,7 +34,7 @@ public extension BlockQuote {
     }
 
     init(_ children: some Sequence<BlockMarkup>, inheritSourceRange: Bool) {
-        let rawChildren = children.map { $0.raw.markup }
+        let rawChildren = children.map { $0._data.raw.markup }
         let parsedRange = inheritSourceRange ? rawChildren.parsedRange : nil
         try! self.init(.blockQuote(parsedRange: parsedRange, rawChildren))
     }

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/CustomBlock.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/CustomBlock.swift
@@ -15,7 +15,7 @@ public struct CustomBlock: BlockMarkup, BasicBlockContainer {
     public var _data: _MarkupData
     init(_ raw: RawMarkup) throws {
         guard case .customBlock = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: CustomBlock.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "CustomBlock")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -34,7 +34,7 @@ public extension CustomBlock {
     }
 
     init(_ children: some Sequence<BlockMarkup>, inheritSourceRange: Bool) {
-        let rawChildren = children.map { $0.raw.markup }
+        let rawChildren = children.map { $0._data.raw.markup }
         let parsedRange = inheritSourceRange ? rawChildren.parsedRange : nil
         try! self.init(.customBlock(parsedRange: parsedRange, rawChildren))
     }

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/CustomBlock.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/CustomBlock.swift
@@ -41,7 +41,9 @@ public extension CustomBlock {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitCustomBlock(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenAbstract.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenAbstract.swift
@@ -32,9 +32,11 @@ public struct DoxygenAbstract: BlockContainer {
         self._data = data
     }
 
+    #if !hasFeature(Embedded)
     public func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitDoxygenAbstract(self)
     }
+    #endif
 }
 
 public extension DoxygenAbstract {

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenAbstract.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenAbstract.swift
@@ -22,7 +22,7 @@ public struct DoxygenAbstract: BlockContainer {
 
     init(_ raw: RawMarkup) throws {
         guard case .doxygenAbstract = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: DoxygenAbstract.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "DoxygenAbstract")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -44,7 +44,7 @@ public extension DoxygenAbstract {
     ///
     /// - Parameter children: Block child elements.
     init<Children: Sequence>(children: Children) where Children.Element == BlockMarkup {
-        try! self.init(.doxygenAbstract(parsedRange: nil, children.map({ $0.raw.markup })))
+        try! self.init(.doxygenAbstract(parsedRange: nil, children.map({ $0._data.raw.markup })))
     }
 
     /// Create a new Doxygen abstract definition.

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenAbstract.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenAbstract.swift
@@ -8,8 +8,6 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-
 /// A parsed Doxygen `\abstract` command.
 ///
 /// The Doxygen support in Swift-Markdown parses `\abstract` commands of the form

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenDiscussion.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenDiscussion.swift
@@ -22,7 +22,7 @@ public struct DoxygenDiscussion: BlockContainer {
 
     init(_ raw: RawMarkup) throws {
         guard case .doxygenDiscussion = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: DoxygenDiscussion.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "DoxygenDiscussion")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -44,7 +44,7 @@ public extension DoxygenDiscussion {
     ///
     /// - Parameter children: Block child elements.
     init<Children: Sequence>(children: Children) where Children.Element == BlockMarkup {
-        try! self.init(.doxygenDiscussion(parsedRange: nil, children.map({ $0.raw.markup })))
+        try! self.init(.doxygenDiscussion(parsedRange: nil, children.map({ $0._data.raw.markup })))
     }
 
     /// Create a new Doxygen discussion definition.

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenDiscussion.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenDiscussion.swift
@@ -8,8 +8,6 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-
 /// A parsed Doxygen `\discussion` command.
 ///
 /// The Doxygen support in Swift-Markdown parses `\discussion` commands of the form

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenDiscussion.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenDiscussion.swift
@@ -32,9 +32,11 @@ public struct DoxygenDiscussion: BlockContainer {
         self._data = data
     }
 
+    #if !hasFeature(Embedded)
     public func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitDoxygenDiscussion(self)
     }
+    #endif
 }
 
 public extension DoxygenDiscussion {

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenNote.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenNote.swift
@@ -22,7 +22,7 @@ public struct DoxygenNote: BlockContainer {
 
     init(_ raw: RawMarkup) throws {
         guard case .doxygenNote = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: DoxygenNote.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "DoxygenNote")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -44,7 +44,7 @@ public extension DoxygenNote {
     ///
     /// - Parameter children: Block child elements.
     init<Children: Sequence>(children: Children) where Children.Element == BlockMarkup {
-        try! self.init(.doxygenNote(parsedRange: nil, children.map({ $0.raw.markup })))
+        try! self.init(.doxygenNote(parsedRange: nil, children.map({ $0._data.raw.markup })))
     }
 
     /// Create a new Doxygen note definition.

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenNote.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenNote.swift
@@ -32,9 +32,11 @@ public struct DoxygenNote: BlockContainer {
         self._data = data
     }
 
+    #if !hasFeature(Embedded)
     public func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitDoxygenNote(self)
     }
+    #endif
 }
 
 public extension DoxygenNote {

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenNote.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenNote.swift
@@ -8,8 +8,6 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-
 /// A parsed Doxygen `\note` command.
 ///
 /// The Doxygen support in Swift-Markdown parses `\note` commands of the form

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenParameter.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenParameter.swift
@@ -25,7 +25,7 @@ public struct DoxygenParameter: BlockContainer {
 
     init(_ raw: RawMarkup) throws {
         guard case .doxygenParam = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: DoxygenParameter.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "DoxygenParameter")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -48,7 +48,7 @@ public extension DoxygenParameter {
     /// - Parameter name: The name of the parameter being described.
     /// - Parameter children: Block child elements.
     init<Children: Sequence>(name: String, children: Children) where Children.Element == BlockMarkup {
-        try! self.init(.doxygenParam(name: name, parsedRange: nil, children.map({ $0.raw.markup })))
+        try! self.init(.doxygenParam(name: name, parsedRange: nil, children.map({ $0._data.raw.markup })))
     }
 
     /// Create a new Doxygen parameter definition.

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenParameter.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenParameter.swift
@@ -35,9 +35,11 @@ public struct DoxygenParameter: BlockContainer {
         self._data = data
     }
 
+    #if !hasFeature(Embedded)
     public func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitDoxygenParameter(self)
     }
+    #endif
 }
 
 public extension DoxygenParameter {

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenParameter.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenParameter.swift
@@ -8,8 +8,6 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-
 /// A parsed Doxygen `\param` command.
 ///
 /// The Doxygen support in Swift-Markdown parses `\param` commands of the form

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenReturns.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenReturns.swift
@@ -32,9 +32,11 @@ public struct DoxygenReturns: BlockContainer {
         self._data = data
     }
 
+    #if !hasFeature(Embedded)
     public func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitDoxygenReturns(self)
     }
+    #endif
 }
 
 public extension DoxygenReturns {

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenReturns.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenReturns.swift
@@ -8,8 +8,6 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-
 /// A parsed Doxygen `\returns`, `\return`, or `\result` command.
 ///
 /// The Doxygen support in Swift-Markdown parses `\returns` commands of the form

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenReturns.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/Doxygen Commands/DoxygenReturns.swift
@@ -22,7 +22,7 @@ public struct DoxygenReturns: BlockContainer {
 
     init(_ raw: RawMarkup) throws {
         guard case .doxygenReturns = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: DoxygenReturns.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "DoxygenReturns")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -44,7 +44,7 @@ public extension DoxygenReturns {
     ///
     /// - Parameter children: Block child elements.
     init<Children: Sequence>(children: Children) where Children.Element == BlockMarkup {
-        try! self.init(.doxygenReturns(parsedRange: nil, children.map({ $0.raw.markup })))
+        try! self.init(.doxygenReturns(parsedRange: nil, children.map({ $0._data.raw.markup })))
     }
 
     /// Create a new Doxygen returns definition.

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/ListItem.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/ListItem.swift
@@ -21,7 +21,7 @@ public struct ListItem: BlockContainer {
     public var _data: _MarkupData
     init(_ raw: RawMarkup) throws {
         guard case .listItem = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: ListItem.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "ListItem")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -39,14 +39,14 @@ public extension ListItem {
     /// - Parameter checkbox: An optional ``Checkbox`` for the list item.
     /// - Parameter children: The child block elements of the list item.
     init(checkbox: Checkbox? = .none, _ children: BlockMarkup...) {
-        try! self.init(.listItem(checkbox: checkbox, parsedRange: nil, children.map { $0.raw.markup }))
+        try! self.init(.listItem(checkbox: checkbox, parsedRange: nil, children.map { $0._data.raw.markup }))
     }
 
     /// Create a list item.
     /// - Parameter checkbox: An optional ``Checkbox`` for the list item.
     /// - Parameter children: The child block elements of the list item.
     init<Children: Sequence>(checkbox: Checkbox? = .none, _ children: Children) where Children.Element == BlockMarkup {
-        try! self.init(.listItem(checkbox: checkbox, parsedRange: nil, children.map { $0.raw.markup }))
+        try! self.init(.listItem(checkbox: checkbox, parsedRange: nil, children.map { $0._data.raw.markup }))
     }
 
     /// An optional ``Checkbox`` for the list item, which can indicate completion of a task, or some other off/on information.

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/ListItem.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/ListItem.swift
@@ -64,7 +64,9 @@ public extension ListItem {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitListItem(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/OrderedList.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/OrderedList.swift
@@ -54,7 +54,9 @@ public extension OrderedList {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitOrderedList(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/OrderedList.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/OrderedList.swift
@@ -13,7 +13,7 @@ public struct OrderedList: ListItemContainer, BlockMarkup {
     public var _data: _MarkupData
     init(_ raw: RawMarkup) throws {
         guard case .orderedList = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: OrderedList.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "OrderedList")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -29,7 +29,7 @@ public extension OrderedList {
     // MARK: ListItemContainer
 
     init<Items: Sequence>(_ items: Items) where Items.Element == ListItem {
-        try! self.init(.orderedList(parsedRange: nil, items.map { $0.raw.markup }))
+        try! self.init(.orderedList(parsedRange: nil, items.map { $0._data.raw.markup }))
     }
 
     /// The starting index for the list.

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/UnorderedList.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/UnorderedList.swift
@@ -13,7 +13,7 @@ public struct UnorderedList: ListItemContainer {
     public var _data: _MarkupData
     init(_ raw: RawMarkup) throws {
         guard case .unorderedList = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: UnorderedList.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "UnorderedList")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -30,7 +30,7 @@ public extension UnorderedList {
     // MARK: ListItemContainer
 
     init<Items: Sequence>(_ items: Items) where Items.Element == ListItem {
-        try! self.init(.unorderedList(parsedRange: nil, items.map { $0.raw.markup }))
+        try! self.init(.unorderedList(parsedRange: nil, items.map { $0._data.raw.markup }))
     }
 
     // MARK: Visitation

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/UnorderedList.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/UnorderedList.swift
@@ -35,7 +35,9 @@ public extension UnorderedList {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitUnorderedList(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Block Nodes/Inline Container Blocks/Paragraph.swift
+++ b/Sources/Markdown/Block Nodes/Inline Container Blocks/Paragraph.swift
@@ -17,7 +17,7 @@ public struct Paragraph: BlockMarkup, BasicInlineContainer {
 
     init(_ raw: RawMarkup) throws {
         guard case .paragraph = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: Paragraph.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "Paragraph")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -34,7 +34,7 @@ public extension Paragraph {
     }
 
     init(_ newChildren: some Sequence<InlineMarkup>, inheritSourceRange: Bool) {
-        let rawChildren = newChildren.map { $0.raw.markup }
+        let rawChildren = newChildren.map { $0._data.raw.markup }
         let parsedRange = inheritSourceRange ? rawChildren.parsedRange : nil
         try! self.init(.paragraph(parsedRange: parsedRange, rawChildren))
     }

--- a/Sources/Markdown/Block Nodes/Inline Container Blocks/Paragraph.swift
+++ b/Sources/Markdown/Block Nodes/Inline Container Blocks/Paragraph.swift
@@ -41,7 +41,9 @@ public extension Paragraph {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitParagraph(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Block Nodes/Leaf Blocks/CodeBlock.swift
+++ b/Sources/Markdown/Block Nodes/Leaf Blocks/CodeBlock.swift
@@ -13,7 +13,7 @@ public struct CodeBlock: BlockMarkup {
     public var _data: _MarkupData
     init(_ raw: RawMarkup) throws {
         guard case .codeBlock = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: CodeBlock.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "CodeBlock")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))

--- a/Sources/Markdown/Block Nodes/Leaf Blocks/CodeBlock.swift
+++ b/Sources/Markdown/Block Nodes/Leaf Blocks/CodeBlock.swift
@@ -60,7 +60,9 @@ public extension CodeBlock {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitCodeBlock(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Block Nodes/Leaf Blocks/HTMLBlock.swift
+++ b/Sources/Markdown/Block Nodes/Leaf Blocks/HTMLBlock.swift
@@ -46,7 +46,9 @@ public extension HTMLBlock {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitHTMLBlock(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Block Nodes/Leaf Blocks/HTMLBlock.swift
+++ b/Sources/Markdown/Block Nodes/Leaf Blocks/HTMLBlock.swift
@@ -13,7 +13,7 @@ public struct HTMLBlock: BlockMarkup, LiteralMarkup {
     public var _data: _MarkupData
     init(_ raw: RawMarkup) throws {
         guard case .htmlBlock = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: HTMLBlock.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "HTMLBlock")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))

--- a/Sources/Markdown/Block Nodes/Leaf Blocks/Heading.swift
+++ b/Sources/Markdown/Block Nodes/Leaf Blocks/Heading.swift
@@ -61,7 +61,9 @@ public extension Heading {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitHeading(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Block Nodes/Leaf Blocks/Heading.swift
+++ b/Sources/Markdown/Block Nodes/Leaf Blocks/Heading.swift
@@ -14,7 +14,7 @@ public struct Heading: BlockMarkup, InlineContainer {
 
     init(_ raw: RawMarkup) throws {
         guard case .heading = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: Heading.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "Heading")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -32,7 +32,7 @@ public extension Heading {
 
     /// Create a heading with a level and a sequence of children.
     init<Children: Sequence>(level: Int, _ children: Children) where Children.Element == InlineMarkup {
-        try! self.init(.heading(level: level, parsedRange: nil, children.map { $0.raw.markup }))
+        try! self.init(.heading(level: level, parsedRange: nil, children.map { $0._data.raw.markup }))
     }
 
     /// The level of the heading, starting at `1`.

--- a/Sources/Markdown/Block Nodes/Leaf Blocks/ThematicBreak.swift
+++ b/Sources/Markdown/Block Nodes/Leaf Blocks/ThematicBreak.swift
@@ -13,7 +13,7 @@ public struct ThematicBreak: BlockMarkup {
     public var _data: _MarkupData
     init(_ raw: RawMarkup) throws {
         guard case .thematicBreak = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: ThematicBreak.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "ThematicBreak")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))

--- a/Sources/Markdown/Block Nodes/Leaf Blocks/ThematicBreak.swift
+++ b/Sources/Markdown/Block Nodes/Leaf Blocks/ThematicBreak.swift
@@ -33,7 +33,9 @@ public extension ThematicBreak {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitThematicBreak(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Block Nodes/Tables/Table.swift
+++ b/Sources/Markdown/Block Nodes/Tables/Table.swift
@@ -38,7 +38,7 @@ public struct Table: BlockMarkup {
 
     init(_ raw: RawMarkup) throws {
         guard case .table = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: Table.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "Table")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))

--- a/Sources/Markdown/Block Nodes/Tables/TableBody.swift
+++ b/Sources/Markdown/Block Nodes/Tables/TableBody.swift
@@ -19,7 +19,7 @@ extension Table {
 
         init(_ raw: RawMarkup) throws {
             guard case .tableBody = raw.data else {
-                throw RawMarkup.Error.concreteConversionError(from: raw, to: Table.Body.self)
+                throw RawMarkup.Error.concreteConversionError(from: raw, to: "Table.Body")
             }
             let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
             self.init(_MarkupData(absoluteRaw))
@@ -39,7 +39,7 @@ extension Table {
 public extension Table.Body {
     /// Create a table body from a sequence of ``Table/Row`` elements.
     init<Rows: Sequence>(_ rows: Rows) where Rows.Element == Table.Row {
-        try! self.init(RawMarkup.tableBody(parsedRange: nil, rows: rows.map { $0.raw.markup }))
+        try! self.init(RawMarkup.tableBody(parsedRange: nil, rows: rows.map { $0._data.raw.markup }))
     }
 
     /// Create a table body from a sequence of ``Table/Row`` elements.
@@ -47,6 +47,22 @@ public extension Table.Body {
         self.init(rows)
     }
 
+    #if hasFeature(Embedded)
+    /// The rows of the body.
+    ///
+    /// - Precondition: All children of a `Table.Body` must be a `Table.Row`.
+    ///
+    /// Embedded variant returns an eagerly-constructed `[Table.Row]`.
+    var rows: [Table.Row] {
+        var result: [Table.Row] = []
+        for child in children {
+            if case .tableRow = child._data.raw.markup.data {
+                result.append(Table.Row(child._data))
+            }
+        }
+        return result
+    }
+    #else
     /// The rows of the body.
     ///
     /// - Precondition: All children of a `ListItemContainer`
@@ -54,6 +70,7 @@ public extension Table.Body {
     var rows: LazyMapSequence<MarkupChildren, Table.Row> {
         return children.lazy.map { $0 as! Table.Row }
     }
+    #endif
 
     /// Replace all list items with a sequence of items.
     mutating func setRows<Rows: Sequence>(_ newRows: Rows) where Rows.Element == Table.Row {
@@ -63,7 +80,7 @@ public extension Table.Body {
     /// Replace list items in a range with a sequence of items.
     mutating func replaceRowsInRange<Rows: Sequence>(_ range: Range<Int>, with incomingRows: Rows) where Rows.Element == Table.Row {
         var rawChildren = raw.markup.copyChildren()
-        rawChildren.replaceSubrange(range, with: incomingRows.map { $0.raw.markup })
+        rawChildren.replaceSubrange(range, with: incomingRows.map { $0._data.raw.markup })
         let newRaw = raw.markup.withChildren(rawChildren)
         _data = _data.replacingSelf(newRaw)
     }

--- a/Sources/Markdown/Block Nodes/Tables/TableCell.swift
+++ b/Sources/Markdown/Block Nodes/Tables/TableCell.swift
@@ -14,7 +14,7 @@ extension Table {
         public var _data: _MarkupData
         init(_ raw: RawMarkup) throws {
             guard case .tableCell = raw.data else {
-                throw RawMarkup.Error.concreteConversionError(from: raw, to: Table.Cell.self)
+                throw RawMarkup.Error.concreteConversionError(from: raw, to: "Table.Cell")
             }
             let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
             self.init(_MarkupData(absoluteRaw))
@@ -79,7 +79,7 @@ public extension Table.Cell {
     }
 
     init(colspan: UInt, rowspan: UInt, _ children: some Sequence<InlineMarkup>, inheritSourceRange: Bool) {
-        let rawChildren = children.map { $0.raw.markup }
+        let rawChildren = children.map { $0._data.raw.markup }
         let parsedRange = inheritSourceRange ? rawChildren.parsedRange : nil
         try! self.init(.tableCell(parsedRange: parsedRange, colspan: colspan, rowspan: rowspan, rawChildren))
     }

--- a/Sources/Markdown/Block Nodes/Tables/TableCellContainer.swift
+++ b/Sources/Markdown/Block Nodes/Tables/TableCellContainer.swift
@@ -37,12 +37,31 @@ public extension TableCellContainer {
         self.init(elements)
     }
 
+    #if hasFeature(Embedded)
+    /// The cells of the row.
+    ///
+    /// - Precondition: All children of a ``TableCellContainer`` must be a `Table.Cell`.
+    ///
+    /// Embedded variant returns an eagerly-constructed `[Table.Cell]` (the
+    /// macOS variant returns a `LazyMapSequence` whose force-cast is
+    /// unavailable in Embedded Swift).
+    var cells: [Table.Cell] {
+        var result: [Table.Cell] = []
+        for child in children {
+            if case .tableCell = child._data.raw.markup.data {
+                result.append(Table.Cell(child._data))
+            }
+        }
+        return result
+    }
+    #else
     /// The cells of the row.
     ///
     /// - Precondition: All children of a ``TableCellContainer`` must be a `Table.Cell`.
     var cells: LazyMapSequence<MarkupChildren, Table.Cell> {
         return children.lazy.map { $0 as! Table.Cell }
     }
+    #endif
 
     /// Replace all cells with a sequence of cells.
     ///
@@ -54,7 +73,7 @@ public extension TableCellContainer {
     /// Replace cells in a range with a sequence of cells.
     mutating func replaceCellsInRange<Cells: Sequence>(_ range: Range<Int>, with incomingCells: Cells) where Cells.Element == Table.Cell {
         var rawChildren = raw.markup.copyChildren()
-        rawChildren.replaceSubrange(range, with: incomingCells.map { $0.raw.markup })
+        rawChildren.replaceSubrange(range, with: incomingCells.map { $0._data.raw.markup })
         let newRaw = raw.markup.withChildren(rawChildren)
         _data = _data.replacingSelf(newRaw)
     }

--- a/Sources/Markdown/Block Nodes/Tables/TableHead.swift
+++ b/Sources/Markdown/Block Nodes/Tables/TableHead.swift
@@ -19,7 +19,7 @@ extension Table {
 
         init(_ raw: RawMarkup) throws {
             guard case .tableHead = raw.data else {
-                throw RawMarkup.Error.concreteConversionError(from: raw, to: Table.Head.self)
+                throw RawMarkup.Error.concreteConversionError(from: raw, to: "Table.Head")
             }
             let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
             self.init(_MarkupData(absoluteRaw))
@@ -33,7 +33,7 @@ public extension Table.Head {
     // MARK: TableCellContainer
 
     init<Cells>(_ cells: Cells) where Cells : Sequence, Cells.Element == Table.Cell {
-        try! self.init(.tableHead(parsedRange: nil, columns: cells.map { $0.raw.markup }))
+        try! self.init(.tableHead(parsedRange: nil, columns: cells.map { $0._data.raw.markup }))
     }
 
     // MARK: Visitation

--- a/Sources/Markdown/Block Nodes/Tables/TableRow.swift
+++ b/Sources/Markdown/Block Nodes/Tables/TableRow.swift
@@ -21,7 +21,7 @@ extension Table {
 
         init(_ raw: RawMarkup) throws {
             guard case .tableRow = raw.data else {
-                throw RawMarkup.Error.concreteConversionError(from: raw, to: Table.Row.self)
+                throw RawMarkup.Error.concreteConversionError(from: raw, to: "Table.Row")
             }
             let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
             self.init(_MarkupData(absoluteRaw))
@@ -36,7 +36,7 @@ public extension Table.Row {
     // MARK: TableCellContainer
 
     init<Cells>(_ cells: Cells) where Cells : Sequence, Cells.Element == Table.Cell {
-        try! self.init(.tableRow(parsedRange: nil, cells.map { $0.raw.markup }))
+        try! self.init(.tableRow(parsedRange: nil, cells.map { $0._data.raw.markup }))
     }
 
     // MARK: Visitation

--- a/Sources/Markdown/Infrastructure/SourceIdentifier.swift
+++ b/Sources/Markdown/Infrastructure/SourceIdentifier.swift
@@ -1,0 +1,20 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+#if canImport(Foundation)
+import Foundation
+public typealias SourceIdentifier = URL
+#else
+/// Lightweight replacement for URL in Embedded Swift contexts.
+public struct SourceIdentifier: Hashable, Sendable {
+    public var path: String
+    public init(path: String) { self.path = path }
+}
+#endif

--- a/Sources/Markdown/Infrastructure/SourceLocation.swift
+++ b/Sources/Markdown/Infrastructure/SourceLocation.swift
@@ -8,7 +8,9 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(Foundation)
 import Foundation
+#endif
 
 /// A location in a source file.
 public struct SourceLocation: Hashable, CustomStringConvertible, Comparable, Sendable {
@@ -29,7 +31,7 @@ public struct SourceLocation: Hashable, CustomStringConvertible, Comparable, Sen
     public var column: Int
 
     /// The source file for which this location applies, if it came from an accessible location.
-    public var source: URL?
+    public var source: SourceIdentifier?
 
     /// Create a source location with line, column, and optional source to which the location applies.
     ///
@@ -37,7 +39,7 @@ public struct SourceLocation: Hashable, CustomStringConvertible, Comparable, Sen
     /// - parameter column: The column of the location, starting with 1.
     /// - parameter source: The URL in which the location resides, or `nil` if there is not a specific
     ///   file or resource that needs to be identified.
-    public init(line: Int, column: Int, source: URL?) {
+    public init(line: Int, column: Int, source: SourceIdentifier?) {
         self.line = line
         self.column = column
         self.source = source

--- a/Sources/Markdown/Inline Nodes/Inline Containers/Emphasis.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/Emphasis.swift
@@ -13,7 +13,7 @@ public struct Emphasis: RecurringInlineMarkup, BasicInlineContainer {
     public var _data: _MarkupData
     init(_ raw: RawMarkup) throws {
         guard case .emphasis = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: Emphasis.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "Emphasis")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -34,7 +34,7 @@ public extension Emphasis {
     }
 
     init(_ newChildren: some Sequence<InlineMarkup>, inheritSourceRange: Bool) {
-        let rawChildren = newChildren.map { $0.raw.markup }
+        let rawChildren = newChildren.map { $0._data.raw.markup }
         let parsedRange = inheritSourceRange ? rawChildren.parsedRange : nil
         try! self.init(.emphasis(parsedRange: parsedRange, rawChildren))
     }
@@ -43,7 +43,7 @@ public extension Emphasis {
 
     var plainText: String {
         let childrenPlainText = children.compactMap {
-            return ($0 as? InlineMarkup)?.plainText
+            return inlinePlainText(of: $0)
         }.joined()
         return "\(childrenPlainText)"
     }

--- a/Sources/Markdown/Inline Nodes/Inline Containers/Emphasis.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/Emphasis.swift
@@ -50,7 +50,9 @@ public extension Emphasis {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitEmphasis(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Inline Nodes/Inline Containers/Image.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/Image.swift
@@ -95,7 +95,9 @@ public extension Image {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitImage(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Inline Nodes/Inline Containers/Image.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/Image.swift
@@ -18,7 +18,7 @@ public struct Image: InlineMarkup, InlineContainer {
 
     init(_ raw: RawMarkup) throws {
         guard case .image = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: Image.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "Image")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -44,7 +44,7 @@ public extension Image {
             sourceToUse = source
         }
 
-        try! self.init(.image(source: sourceToUse, title: titleToUse, parsedRange: nil, children.map { $0.raw.markup }))
+        try! self.init(.image(source: sourceToUse, title: titleToUse, parsedRange: nil, children.map { $0._data.raw.markup }))
     }
 
     /// Create an image from a source and zero or more child inline elements.

--- a/Sources/Markdown/Inline Nodes/Inline Containers/InlineAttributes.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/InlineAttributes.swift
@@ -53,7 +53,9 @@ public extension InlineAttributes {
     
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitInlineAttributes(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Inline Nodes/Inline Containers/InlineAttributes.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/InlineAttributes.swift
@@ -14,7 +14,7 @@ public struct InlineAttributes: InlineMarkup, InlineContainer {
 
     init(_ raw: RawMarkup) throws {
         guard case .inlineAttributes = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: InlineAttributes.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "InlineAttributes")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -30,7 +30,7 @@ public struct InlineAttributes: InlineMarkup, InlineContainer {
 public extension InlineAttributes {
     /// Create a set of custom inline attributes applied to zero or more child inline elements.
     init<Children: Sequence>(attributes: String, _ children: Children) where Children.Element == RecurringInlineMarkup {
-        try! self.init(.inlineAttributes(attributes: attributes, parsedRange: nil, children.map { $0.raw.markup }))
+        try! self.init(.inlineAttributes(attributes: attributes, parsedRange: nil, children.map { $0._data.raw.markup }))
     }
 
     /// Create a set of custom attributes applied to zero or more child inline elements.

--- a/Sources/Markdown/Inline Nodes/Inline Containers/Link.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/Link.swift
@@ -98,7 +98,9 @@ public extension Link {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitLink(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Inline Nodes/Inline Containers/Link.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/Link.swift
@@ -14,7 +14,7 @@ public struct Link: InlineMarkup, InlineContainer {
 
     init(_ raw: RawMarkup) throws {
         guard case .link = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: Link.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "Link")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -44,7 +44,7 @@ public extension Link {
             titleToUse = title
         }
 
-        try! self.init(.link(destination: destinationToUse, title: titleToUse, parsedRange: nil, children.map { $0.raw.markup }))
+        try! self.init(.link(destination: destinationToUse, title: titleToUse, parsedRange: nil, children.map { $0._data.raw.markup }))
     }
 
     /// Create a link with a destination and zero or more child inline elements.

--- a/Sources/Markdown/Inline Nodes/Inline Containers/Strikethrough.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/Strikethrough.swift
@@ -49,7 +49,9 @@ public extension Strikethrough {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitStrikethrough(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Inline Nodes/Inline Containers/Strikethrough.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/Strikethrough.swift
@@ -13,7 +13,7 @@ public struct Strikethrough: RecurringInlineMarkup, BasicInlineContainer {
     public var _data: _MarkupData
     init(_ raw: RawMarkup) throws {
         guard case .strikethrough = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: Strikethrough.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "Strikethrough")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -33,7 +33,7 @@ public extension Strikethrough {
     }
 
     init(_ newChildren: some Sequence<InlineMarkup>, inheritSourceRange: Bool) {
-        let rawChildren = newChildren.map { $0.raw.markup }
+        let rawChildren = newChildren.map { $0._data.raw.markup }
         let parsedRange = inheritSourceRange ? rawChildren.parsedRange : nil
         try! self.init(.strikethrough(parsedRange: parsedRange, rawChildren))
     }
@@ -42,7 +42,7 @@ public extension Strikethrough {
 
     var plainText: String {
         let childrenPlainText = children.compactMap {
-            return ($0 as? InlineMarkup)?.plainText
+            return inlinePlainText(of: $0)
         }.joined()
         return "~\(childrenPlainText)~"
     }

--- a/Sources/Markdown/Inline Nodes/Inline Containers/Strong.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/Strong.swift
@@ -13,7 +13,7 @@ public struct Strong: RecurringInlineMarkup, BasicInlineContainer {
     public var _data: _MarkupData
     init(_ raw: RawMarkup) throws {
         guard case .strong = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: Strong.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "Strong")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))
@@ -33,7 +33,7 @@ public extension Strong {
     }
 
     init(_ newChildren: some Sequence<InlineMarkup>, inheritSourceRange: Bool) {
-        let rawChildren = newChildren.map { $0.raw.markup }
+        let rawChildren = newChildren.map { $0._data.raw.markup }
         let parsedRange = inheritSourceRange ? rawChildren.parsedRange : nil
         try! self.init(.strong(parsedRange: parsedRange, rawChildren))
     }
@@ -42,7 +42,7 @@ public extension Strong {
 
     var plainText: String {
         let childrenPlainText = children.compactMap {
-            return ($0 as? InlineMarkup)?.plainText
+            return inlinePlainText(of: $0)
         }.joined()
         return "\(childrenPlainText)"
     }

--- a/Sources/Markdown/Inline Nodes/Inline Containers/Strong.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/Strong.swift
@@ -49,7 +49,9 @@ public extension Strong {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitStrong(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Inline Nodes/Inline Leaves/CustomInline.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Leaves/CustomInline.swift
@@ -15,7 +15,7 @@ public struct CustomInline: RecurringInlineMarkup {
     public var _data: _MarkupData
     init(_ raw: RawMarkup) throws {
         guard case .customInline = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: CustomInline.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "CustomInline")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))

--- a/Sources/Markdown/Inline Nodes/Inline Leaves/CustomInline.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Leaves/CustomInline.swift
@@ -48,7 +48,9 @@ public extension CustomInline {
         return text
     }
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitCustomInline(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Inline Nodes/Inline Leaves/InlineCode.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Leaves/InlineCode.swift
@@ -54,7 +54,9 @@ public extension InlineCode {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitInlineCode(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Inline Nodes/Inline Leaves/InlineCode.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Leaves/InlineCode.swift
@@ -14,7 +14,7 @@ public struct InlineCode: RecurringInlineMarkup {
 
     init(_ raw: RawMarkup) throws {
         guard case .inlineCode = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: InlineCode.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "InlineCode")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))

--- a/Sources/Markdown/Inline Nodes/Inline Leaves/InlineHTML.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Leaves/InlineHTML.swift
@@ -13,7 +13,7 @@ public struct InlineHTML: RecurringInlineMarkup, LiteralMarkup {
     public var _data: _MarkupData
     init(_ raw: RawMarkup) throws {
         guard case .inlineHTML = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: InlineHTML.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "InlineHTML")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))

--- a/Sources/Markdown/Inline Nodes/Inline Leaves/InlineHTML.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Leaves/InlineHTML.swift
@@ -52,7 +52,9 @@ public extension InlineHTML {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitInlineHTML(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Inline Nodes/Inline Leaves/LineBreak.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Leaves/LineBreak.swift
@@ -18,7 +18,7 @@ public struct LineBreak: RecurringInlineMarkup {
 
     init(_ raw: RawMarkup) throws {
         guard case .lineBreak = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: LineBreak.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "LineBreak")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))

--- a/Sources/Markdown/Inline Nodes/Inline Leaves/LineBreak.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Leaves/LineBreak.swift
@@ -41,7 +41,9 @@ public extension LineBreak {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitLineBreak(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Inline Nodes/Inline Leaves/SoftBreak.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Leaves/SoftBreak.swift
@@ -41,7 +41,9 @@ public extension SoftBreak {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitSoftBreak(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Inline Nodes/Inline Leaves/SoftBreak.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Leaves/SoftBreak.swift
@@ -14,7 +14,7 @@ public struct SoftBreak: RecurringInlineMarkup {
 
     init(_ raw: RawMarkup) throws {
         guard case .softBreak = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: SoftBreak.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "SoftBreak")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))

--- a/Sources/Markdown/Inline Nodes/Inline Leaves/SymbolLink.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Leaves/SymbolLink.swift
@@ -21,7 +21,7 @@ public struct SymbolLink: InlineMarkup {
 
     init(_ raw: RawMarkup) throws {
         guard case .symbolLink = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: SymbolLink.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "SymbolLink")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))

--- a/Sources/Markdown/Inline Nodes/Inline Leaves/SymbolLink.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Leaves/SymbolLink.swift
@@ -59,9 +59,11 @@ public extension SymbolLink {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitSymbolLink(self)
     }
+    #endif
 
     // MARK: PlainTextConvertibleMarkup
 

--- a/Sources/Markdown/Inline Nodes/Inline Leaves/Text.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Leaves/Text.swift
@@ -14,7 +14,7 @@ public struct Text: RecurringInlineMarkup, LiteralMarkup {
 
     init(_ raw: RawMarkup) throws {
         guard case .text = raw.data else {
-            throw RawMarkup.Error.concreteConversionError(from: raw, to: Text.self)
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: "Text")
         }
         let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
         self.init(_MarkupData(absoluteRaw))

--- a/Sources/Markdown/Inline Nodes/Inline Leaves/Text.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Leaves/Text.swift
@@ -53,7 +53,9 @@ public extension Text {
 
     // MARK: Visitation
 
+    #if !hasFeature(Embedded)
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
         return visitor.visitText(self)
     }
+    #endif
 }

--- a/Sources/Markdown/Interpretive Nodes/Aside.swift
+++ b/Sources/Markdown/Interpretive Nodes/Aside.swift
@@ -8,8 +8,6 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-
 /// An auxiliary aside element interpreted from a block quote.
 ///
 /// Asides are written as a block quote starting with a special plain-text tag,

--- a/Sources/Markdown/Interpretive Nodes/Aside.swift
+++ b/Sources/Markdown/Interpretive Nodes/Aside.swift
@@ -18,6 +18,7 @@
 /// > It may have a presentation similar to a block quote, but with a
 /// > different meaning, as it doesn't quote speech.
 /// ```
+#if !hasFeature(Embedded)
 public struct Aside {
     /// Describes the different kinds of aside.
     public struct Kind: RawRepresentable, CaseIterable, Equatable, Sendable {
@@ -204,7 +205,9 @@ public struct Aside {
         self.content = Array(kindTag.newBlockQuote.blockChildren)
     }
 }
+#endif
 
+#if !hasFeature(Embedded)
 extension BlockQuote {
     func parseAsideTag(tagRequirement: Aside.TagRequirement) -> (tag: String, newBlockQuote: BlockQuote)? {
         guard let initialText = self.child(through: [
@@ -247,3 +250,4 @@ extension BlockQuote {
         return (String(kindTag), newBlockQuote)
     }
 }
+#endif

--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -542,7 +542,7 @@ private enum ParseContainer: CustomStringConvertible {
         }
 
         mutating private func print<S: StringProtocol>(_ text: S) {
-            let lines = text.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
+            let lines = text.split(omittingEmptySubsequences: false, whereSeparator: { $0.isNewline })
             for i in lines.indices {
                 if i != lines.startIndex {
                     queueNewline()
@@ -719,7 +719,7 @@ private enum ParseContainer: CustomStringConvertible {
             // Write back the adjusted ranges.
             ranges = columnAdjuster.ranges
 
-            return parsedSubdocument.children.map { $0.raw.markup }
+            return parsedSubdocument.children.map { $0._data.raw.markup }
         case let .blockDirective(pendingBlockDirective, children):
             let range = pendingBlockDirective.atLocation..<pendingBlockDirective.endLocation
             ranges.add(range)
@@ -736,7 +736,7 @@ private enum ParseContainer: CustomStringConvertible {
                         if let argumentRange = $0.range {
                             // If the argument has a known source range, offset the column (number of UTF8 bytes) to find the start of the line.
                             lineStartIndex = base.utf8.index($0.text.startIndex, offsetBy: 1 - argumentRange.lowerBound.column)
-                        } else if let newLineIndex = base[..<$0.text.startIndex].lastIndex(where: \.isNewline) {
+                        } else if let newLineIndex = base[..<$0.text.startIndex].lastIndex(where: { $0.isNewline }) {
                             // Iterate backwards from the argument start index to find the the start of the line.
                             lineStartIndex = base.utf8.index(after: newLineIndex)
                         } else {

--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -8,7 +8,9 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(Foundation)
 import Foundation
+#endif
 
 struct PendingBlockDirective {
     enum ParseState {
@@ -299,7 +301,7 @@ struct TrimmedLine {
 
     /// The source file or resource from which the line came,
     /// or `nil` if no such file or resource can be identified.
-    let source: URL?
+    let source: SourceIdentifier?
 
     /// `true` if this line is empty or consists of all space `" "` or tab
     /// `"\t"` characters.
@@ -314,7 +316,7 @@ struct TrimmedLine {
     ///   - source: The source file or resource from which the line came, or `nil` if no such file or resource can be identified.
     ///   - lineNumber: The line number of this line in the source if known, starting with `0`.
     ///   - parseIndex: The current index a parser is looking at on a line, or `nil` if a parser is looking at the start of the untrimmed text.
-    init(_ untrimmedText: Substring, source: URL?, lineNumber: Int?, parseIndex: Substring.Index? = nil) {
+    init(_ untrimmedText: Substring, source: SourceIdentifier?, lineNumber: Int?, parseIndex: Substring.Index? = nil) {
         self.untrimmedText = untrimmedText
         self.source = source
         self.parseIndex = parseIndex ?? untrimmedText.startIndex
@@ -1132,7 +1134,7 @@ extension Document {
     /// Convert a ``ParseContainer` to a ``Document``.
     ///
     /// - Precondition: The `rootContainer` must be the `.root` case.
-    fileprivate init(converting rootContainer: ParseContainer, from source: URL?,
+    fileprivate init(converting rootContainer: ParseContainer, from source: SourceIdentifier?,
                      options: ParseOptions) {
         guard case .root = rootContainer else {
             fatalError("Tried to convert a non-root container to a `Document`")
@@ -1156,13 +1158,15 @@ extension Document {
 }
 
 struct BlockDirectiveParser {
+    #if canImport(Foundation)
     static func parse(_ input: URL, options: ParseOptions = []) throws -> Document {
         let string = try String(contentsOf: input, encoding: .utf8)
         return parse(string, source: input, options: options)
     }
+    #endif
 
     /// Parse the input.
-    static func parse(_ input: String, source: URL?,
+    static func parse(_ input: String, source: SourceIdentifier?,
                       options: ParseOptions = []) -> Document {
         // Phase 0: Split the input into lines lazily, keeping track of
         // line numbers, consecutive blank lines, and start positions on each line where indentation ends.

--- a/Sources/Markdown/Parser/CommonMarkConverter.swift
+++ b/Sources/Markdown/Parser/CommonMarkConverter.swift
@@ -10,7 +10,9 @@
 
 import cmark_gfm
 import cmark_gfm_extensions
+#if canImport(Foundation)
 import Foundation
+#endif
 
 /// String-based CommonMark node type identifiers.
 ///
@@ -82,7 +84,7 @@ fileprivate struct MarkupConverterState {
         var range: SourceRange?
     }
     /// The original source whose conversion created this state.
-    let source: URL?
+    let source: SourceIdentifier?
 
     /// An opaque pointer to a `cmark_iter` used during parsing.
     let iterator: UnsafeMutablePointer<cmark_iter>?
@@ -99,7 +101,7 @@ fileprivate struct MarkupConverterState {
     private(set) var headerSeen: Bool
     private(set) var pendingTableBody: PendingTableBody?
 
-    init(source: URL?, iterator: UnsafeMutablePointer<cmark_iter>?, event: cmark_event_type, node: UnsafeMutablePointer<cmark_node>?, options: ParseOptions, headerSeen: Bool, pendingTableBody: PendingTableBody?) {
+    init(source: SourceIdentifier?, iterator: UnsafeMutablePointer<cmark_iter>?, event: cmark_event_type, node: UnsafeMutablePointer<cmark_node>?, options: ParseOptions, headerSeen: Bool, pendingTableBody: PendingTableBody?) {
         self.source = source
         self.iterator = iterator
         self.event = event
@@ -608,7 +610,7 @@ struct MarkupParser {
         return MarkupConversion(state: childConversion.state.next(), result: .inlineAttributes(attributes: attributes, parsedRange: parsedRange, childConversion.result))
      }
 
-    static func parseString(_ string: String, source: URL?, options: ParseOptions) -> Document {
+    static func parseString(_ string: String, source: SourceIdentifier?, options: ParseOptions) -> Document {
         cmark_gfm_core_extensions_ensure_registered()
 
         var cmarkOptions = CMARK_OPT_TABLE_SPANS

--- a/Sources/Markdown/Parser/LazySplitLines.swift
+++ b/Sources/Markdown/Parser/LazySplitLines.swift
@@ -8,7 +8,9 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(Foundation)
 import Foundation
+#endif
 
 /// A lazy sequence of split lines that keeps track of initial indentation and
 /// consecutive runs of empty lines.
@@ -25,9 +27,9 @@ struct LazySplitLines: Sequence {
 
         /// The source file or resource from which the line came,
         /// or `nil` if no such file or resource can be identified.
-        private var source: URL?
+        private var source: SourceIdentifier?
 
-        init<S: StringProtocol>(_ input: S, source: URL?) where S.SubSequence == Substring {
+        init<S: StringProtocol>(_ input: S, source: SourceIdentifier?) where S.SubSequence == Substring {
             self.rawLines = input.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
             self.index = rawLines.startIndex
             self.source = source
@@ -57,9 +59,9 @@ struct LazySplitLines: Sequence {
 
     /// The source file or resource from which the line came,
     /// or `nil` if no such file or resource can be identified.
-    private let source: URL?
+    private let source: SourceIdentifier?
 
-    init(_ input: Substring, source: URL?) {
+    init(_ input: Substring, source: SourceIdentifier?) {
         self.input = input
         self.source = source
     }

--- a/Sources/Markdown/Parser/LazySplitLines.swift
+++ b/Sources/Markdown/Parser/LazySplitLines.swift
@@ -30,7 +30,7 @@ struct LazySplitLines: Sequence {
         private var source: SourceIdentifier?
 
         init<S: StringProtocol>(_ input: S, source: SourceIdentifier?) where S.SubSequence == Substring {
-            self.rawLines = input.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
+            self.rawLines = input.split(omittingEmptySubsequences: false, whereSeparator: { $0.isNewline })
             self.index = rawLines.startIndex
             self.source = source
         }

--- a/Sources/Markdown/Parser/RangeAdjuster.swift
+++ b/Sources/Markdown/Parser/RangeAdjuster.swift
@@ -43,7 +43,11 @@ struct RangeAdjuster: MarkupWalker {
         markup.raw.markup.header.parsedRange = adjustedRange
 
         for child in markup.children {
+            #if hasFeature(Embedded)
+            visit(child)
+            #else
             child.accept(&self)
+            #endif
         }
 
         // End unsafe stuff.

--- a/Sources/Markdown/Parser/RangeAdjuster.swift
+++ b/Sources/Markdown/Parser/RangeAdjuster.swift
@@ -40,7 +40,7 @@ struct RangeAdjuster: MarkupWalker {
         // Unsafe mutation of shared reference types.
         // This should only ever be called during parsing.
 
-        markup.raw.markup.header.parsedRange = adjustedRange
+        markup._data.raw.markup.header.parsedRange = adjustedRange
 
         for child in markup.children {
             #if hasFeature(Embedded)

--- a/Sources/Markdown/Rewriter/MarkupRewriter.swift
+++ b/Sources/Markdown/Rewriter/MarkupRewriter.swift
@@ -13,7 +13,7 @@ public protocol MarkupRewriter: MarkupVisitor where Result == Markup? {}
 
 extension MarkupRewriter {
     public mutating func defaultVisit(_ markup: Markup) -> Markup? {
-        let newChildren = markup.children.compactMap {
+        let newChildren: [Markup] = markup.children.compactMap {
             return self.visit($0)
         }
         return markup.withUncheckedChildren(newChildren)

--- a/Sources/Markdown/Structural Restrictions/BlockContainer.swift
+++ b/Sources/Markdown/Structural Restrictions/BlockContainer.swift
@@ -14,6 +14,7 @@ public protocol BlockContainer: BlockMarkup {}
 // MARK: - Public API
 
 public extension BlockContainer {
+    #if !hasFeature(Embedded)
     /// The inline child elements of this element.
     ///
     /// - Precondition: All children of an `InlineContainer`
@@ -21,6 +22,7 @@ public extension BlockContainer {
     var blockChildren: LazyMapSequence<MarkupChildren, BlockMarkup> {
         return children.lazy.map { $0 as! BlockMarkup }
     }
+    #endif
 
     /// Replace all inline child elements with a new sequence of inline elements.
     mutating func setBlockChildren<Items: Sequence>(_ newChildren: Items) where Items.Element == BlockMarkup {
@@ -30,7 +32,7 @@ public extension BlockContainer {
     /// Replace child inline elements in a range with a new sequence of elements.
     mutating func replaceChildrenInRange<Items: Sequence>(_ range: Range<Int>, with incomingItems: Items) where Items.Element == BlockMarkup {
         var rawChildren = raw.markup.copyChildren()
-        rawChildren.replaceSubrange(range, with: incomingItems.map { $0.raw.markup })
+        rawChildren.replaceSubrange(range, with: incomingItems.map { $0._data.raw.markup })
         let newRaw = raw.markup.withChildren(rawChildren)
         _data = _data.replacingSelf(newRaw)
     }

--- a/Sources/Markdown/Structural Restrictions/InlineContainer.swift
+++ b/Sources/Markdown/Structural Restrictions/InlineContainer.swift
@@ -14,6 +14,7 @@ public protocol InlineContainer: PlainTextConvertibleMarkup {}
 // MARK: - Public API
 
 public extension InlineContainer {
+    #if !hasFeature(Embedded)
     /// The inline child elements of this element.
     ///
     /// - Precondition: All children of an `InlineContainer`
@@ -21,6 +22,7 @@ public extension InlineContainer {
     var inlineChildren: LazyMapSequence<MarkupChildren, InlineMarkup> {
         return children.lazy.map { $0 as! InlineMarkup }
     }
+    #endif
 
     /// Replace all inline child elements with a new sequence of inline elements.
     mutating func setInlineChildren<Items: Sequence>(_ newChildren: Items) where Items.Element == InlineMarkup {
@@ -30,7 +32,7 @@ public extension InlineContainer {
     /// Replace child inline elements in a range with a new sequence of elements.
     mutating func replaceChildrenInRange<Items: Sequence>(_ range: Range<Int>, with incomingItems: Items) where Items.Element == InlineMarkup {
         var rawChildren = raw.markup.copyChildren()
-        rawChildren.replaceSubrange(range, with: incomingItems.map { $0.raw.markup })
+        rawChildren.replaceSubrange(range, with: incomingItems.map { $0._data.raw.markup })
         let newRaw = raw.markup.withChildren(rawChildren)
         _data = _data.replacingSelf(newRaw)
     }
@@ -39,7 +41,7 @@ public extension InlineContainer {
 
     var plainText: String {
         return children.compactMap {
-            return ($0 as? InlineMarkup)?.plainText
+            return inlinePlainText(of: $0)
         }.joined()
     }
 }

--- a/Sources/Markdown/Structural Restrictions/InlineMarkup.swift
+++ b/Sources/Markdown/Structural Restrictions/InlineMarkup.swift
@@ -17,3 +17,43 @@ public protocol InlineMarkup: PlainTextConvertibleMarkup {}
 /// example, you cannot put a ``Link`` inside another ``Link`` or an ``Image``
 /// inside another ``Image``.
 public protocol RecurringInlineMarkup: InlineMarkup {}
+
+/// If `markup` is an inline markup element, return its `plainText`.
+/// Otherwise return `nil`.
+///
+/// This is the Embedded-Swift–compatible equivalent of
+/// `(markup as? InlineMarkup)?.plainText`. It dispatches on the concrete
+/// kind of the underlying raw markup data instead of using a dynamic cast,
+/// which is unavailable in Embedded Swift.
+internal func inlinePlainText(of markup: Markup) -> String? {
+    switch markup._data.raw.markup.data {
+    case .text:
+        return Text(markup._data).plainText
+    case .emphasis:
+        return Emphasis(markup._data).plainText
+    case .strong:
+        return Strong(markup._data).plainText
+    case .image:
+        return Image(markup._data).plainText
+    case .inlineCode:
+        return InlineCode(markup._data).plainText
+    case .softBreak:
+        return SoftBreak(markup._data).plainText
+    case .lineBreak:
+        return LineBreak(markup._data).plainText
+    case .inlineHTML:
+        return InlineHTML(markup._data).plainText
+    case .strikethrough:
+        return Strikethrough(markup._data).plainText
+    case .link:
+        return Link(markup._data).plainText
+    case .symbolLink:
+        return SymbolLink(markup._data).plainText
+    case .customInline:
+        return CustomInline(markup._data).plainText
+    case .inlineAttributes:
+        return InlineAttributes(markup._data).plainText
+    default:
+        return nil
+    }
+}

--- a/Sources/Markdown/Structural Restrictions/ListItemContainer.swift
+++ b/Sources/Markdown/Structural Restrictions/ListItemContainer.swift
@@ -26,6 +26,23 @@ public extension ListItemContainer {
         self.init(items)
     }
 
+    #if hasFeature(Embedded)
+    /// The items of the list.
+    ///
+    /// - Precondition: All children of a `ListItemContainer`
+    ///   must be a `ListItem`.
+    ///
+    /// Embedded variant returns an eagerly-constructed `[ListItem]`.
+    var listItems: [ListItem] {
+        var result: [ListItem] = []
+        for child in children {
+            if case .listItem = child._data.raw.markup.data {
+                result.append(ListItem(child._data))
+            }
+        }
+        return result
+    }
+    #else
     /// The items of the list.
     ///
     /// - Precondition: All children of a `ListItemContainer`
@@ -33,6 +50,7 @@ public extension ListItemContainer {
     var listItems: LazyMapSequence<MarkupChildren, ListItem> {
         return children.lazy.map { $0 as! ListItem }
     }
+    #endif
 
     /// Replace all list items with a sequence of items.
     mutating func setListItems<Items: Sequence>(_ newItems: Items) where Items.Element == ListItem {
@@ -42,7 +60,7 @@ public extension ListItemContainer {
     /// Replace list items in a range with a sequence of items.
     mutating func replaceItemsInRange<Items: Sequence>(_ range: Range<Int>, with incomingItems: Items) where Items.Element == ListItem {
         var rawChildren = raw.markup.copyChildren()
-        rawChildren.replaceSubrange(range, with: incomingItems.map { $0.raw.markup })
+        rawChildren.replaceSubrange(range, with: incomingItems.map { $0._data.raw.markup })
         let newRaw = raw.markup.withChildren(rawChildren)
         _data = _data.replacingSelf(newRaw)
     }

--- a/Sources/Markdown/Visitor/MarkupVisitor.swift
+++ b/Sources/Markdown/Visitor/MarkupVisitor.swift
@@ -317,12 +317,56 @@ public protocol MarkupVisitor<Result> {
 }
 
 extension MarkupVisitor {
+    #if hasFeature(Embedded)
+    // Embedded Swift cannot call generic methods on existentials, so we use
+    // enum-based dispatch instead of the accept<V> virtual dispatch pattern.
+    public mutating func visit(_ markup: Markup) -> Result {
+        switch markup._data.raw.markup.data {
+        case .blockQuote: return visitBlockQuote(BlockQuote(markup._data))
+        case .codeBlock: return visitCodeBlock(CodeBlock(markup._data))
+        case .customBlock: return visitCustomBlock(CustomBlock(markup._data))
+        case .document: return visitDocument(Document(markup._data))
+        case .heading: return visitHeading(Heading(markup._data))
+        case .thematicBreak: return visitThematicBreak(ThematicBreak(markup._data))
+        case .htmlBlock: return visitHTMLBlock(HTMLBlock(markup._data))
+        case .listItem: return visitListItem(ListItem(markup._data))
+        case .orderedList: return visitOrderedList(OrderedList(markup._data))
+        case .unorderedList: return visitUnorderedList(UnorderedList(markup._data))
+        case .paragraph: return visitParagraph(Paragraph(markup._data))
+        case .blockDirective: return visitBlockDirective(BlockDirective(markup._data))
+        case .inlineCode: return visitInlineCode(InlineCode(markup._data))
+        case .customInline: return visitCustomInline(CustomInline(markup._data))
+        case .emphasis: return visitEmphasis(Emphasis(markup._data))
+        case .image: return visitImage(Image(markup._data))
+        case .inlineHTML: return visitInlineHTML(InlineHTML(markup._data))
+        case .lineBreak: return visitLineBreak(LineBreak(markup._data))
+        case .link: return visitLink(Link(markup._data))
+        case .softBreak: return visitSoftBreak(SoftBreak(markup._data))
+        case .strong: return visitStrong(Strong(markup._data))
+        case .text: return visitText(Text(markup._data))
+        case .symbolLink: return visitSymbolLink(SymbolLink(markup._data))
+        case .inlineAttributes: return visitInlineAttributes(InlineAttributes(markup._data))
+        case .strikethrough: return visitStrikethrough(Strikethrough(markup._data))
+        case .table: return visitTable(Table(markup._data))
+        case .tableHead: return visitTableHead(Table.Head(markup._data))
+        case .tableBody: return visitTableBody(Table.Body(markup._data))
+        case .tableRow: return visitTableRow(Table.Row(markup._data))
+        case .tableCell: return visitTableCell(Table.Cell(markup._data))
+        case .doxygenDiscussion: return visitDoxygenDiscussion(DoxygenDiscussion(markup._data))
+        case .doxygenNote: return visitDoxygenNote(DoxygenNote(markup._data))
+        case .doxygenAbstract: return visitDoxygenAbstract(DoxygenAbstract(markup._data))
+        case .doxygenParam: return visitDoxygenParameter(DoxygenParameter(markup._data))
+        case .doxygenReturns: return visitDoxygenReturns(DoxygenReturns(markup._data))
+        }
+    }
+    #else
     // Default implementation: call `accept` on the markup element,
     // dispatching into each leaf element's implementation, which then
     // dispatches to the correct visit___ method.
     public mutating func visit(_ markup: Markup) -> Result {
         return markup.accept(&self)
     }
+    #endif
     public mutating func visitBlockQuote(_ blockQuote: BlockQuote) -> Result {
         return defaultVisit(blockQuote)
     }

--- a/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
@@ -8,7 +8,23 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(Foundation)
 import Foundation
+#endif
+
+fileprivate extension String {
+    func _replacingOccurrences(of target: Character, with replacement: String) -> String {
+        var result = ""
+        for char in self {
+            if char == target {
+                result += replacement
+            } else {
+                result.append(char)
+            }
+        }
+        return result
+    }
+}
 
 /// Options given to the ``HTMLFormatter``.
 public struct HTMLFormatterOptions: OptionSet {
@@ -286,8 +302,9 @@ public struct HTMLFormatter: MarkupWalker {
     }
 
     public mutating func visitInlineAttributes(_ attributes: InlineAttributes) -> () {
-        result += "<span data-attributes=\"\(attributes.attributes.replacingOccurrences(of: "\"", with: "\\\""))\""
+        result += "<span data-attributes=\"\(attributes.attributes._replacingOccurrences(of: "\"" as Character, with: "\\\""))\""
 
+        #if canImport(Foundation)
         let wrappedAttributes = "{\(attributes.attributes)}"
         if options.contains(.parseInlineAttributeClass),
            let attributesData = wrappedAttributes.data(using: .utf8)
@@ -315,6 +332,7 @@ public struct HTMLFormatter: MarkupWalker {
                 result += " class=\"\(parsedAttributes.class)\""
             }
         }
+        #endif
 
         result += ">"
         descendInto(attributes)

--- a/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
@@ -82,6 +82,7 @@ public struct HTMLFormatter: MarkupWalker {
     // MARK: Block elements
 
     public mutating func visitBlockQuote(_ blockQuote: BlockQuote) -> () {
+        #if !hasFeature(Embedded)
         if self.options.contains(.parseAsides), let aside = Aside(blockQuote, tagRequirement: .requireSingleWordTag) {
             result += "<aside data-kind=\"\(aside.kind.rawValue)\">\n"
             for child in aside.content {
@@ -93,6 +94,11 @@ public struct HTMLFormatter: MarkupWalker {
             descendInto(blockQuote)
             result += "</blockquote>\n"
         }
+        #else
+        result += "<blockquote>\n"
+        descendInto(blockQuote)
+        result += "</blockquote>\n"
+        #endif
     }
 
     public mutating func visitCodeBlock(_ codeBlock: CodeBlock) -> () {

--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -8,7 +8,9 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(Foundation)
 import Foundation
+#endif
 
 fileprivate extension Markup {
     /// The parental chain of elements from a root to this element.
@@ -596,7 +598,7 @@ public struct MarkupFormatter: MarkupWalker {
             return
         }
 
-        let words = string.components(separatedBy: CharacterSet(charactersIn: " \t"))[...]
+        let words = string.split(omittingEmptySubsequences: false, whereSeparator: { $0 == " " || $0 == "\t" }).map(String.init)[...]
 
         /// Hard line breaks in Markdown require two spaces before the newline; soft breaks require none.
         let breakSuffix: String

--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -12,50 +12,98 @@
 import Foundation
 #endif
 
-fileprivate extension Markup {
-    /// The parental chain of elements from a root to this element.
-    var parentalChain: [Markup] {
-        var stack: [Markup] = [self]
-        var current: Markup = self
-        while let parent = current.parent {
-            stack.append(parent)
-            current = parent
-        }
-        return stack.reversed()
+/// The parental chain of elements from a root to the given element.
+fileprivate func parentalChain(of markup: Markup) -> [Markup] {
+    var stack: [Markup] = [markup]
+    var current: Markup = markup
+    while let parent = current.parent {
+        stack.append(parent)
+        current = parent
     }
+    return stack.reversed()
+}
 
-    /// Return the first ancestor that matches a condition, or `nil` if there is no such ancestor.
-    func firstAncestor(where ancestorMatches: (Markup) -> Bool) -> Markup? {
-        var currentParent = parent
-        while let current = currentParent {
-            if ancestorMatches(current) {
-                return current
-            }
-            currentParent = current.parent
+/// Return the first ancestor of `markup` that matches a condition,
+/// or `nil` if there is no such ancestor.
+fileprivate func firstAncestor(of markup: Markup, where ancestorMatches: (Markup) -> Bool) -> Markup? {
+    var currentParent = markup.parent
+    while let current = currentParent {
+        if ancestorMatches(current) {
+            return current
         }
+        currentParent = current.parent
+    }
+    return nil
+}
+
+/// Previous sibling of `markup` in its parent, or `nil` if it's the first child.
+fileprivate func previousSibling(of markup: Markup) -> Markup? {
+    guard let parent = markup.parent, markup.indexInParent > 0 else {
         return nil
     }
+    return parent.child(at: markup.indexInParent - 1)
+}
 
-    /// Previous sibling of this element in its parent, or `nil` if it's the first child.
-    var previousSibling: Markup? {
-        guard let parent, indexInParent > 0 else {
-            return nil
-        }
-
-        return parent.child(at: indexInParent - 1)
+/// Whether `markup` is a Doxygen command.
+fileprivate func isDoxygenCommand(_ markup: Markup) -> Bool {
+    switch markup._data.raw.markup.data {
+    case .doxygenDiscussion, .doxygenNote, .doxygenAbstract,
+         .doxygenParam, .doxygenReturns:
+        return true
+    default:
+        return false
     }
+}
 
-    /// Whether this element is a Doxygen command.
-    var isDoxygenCommand: Bool {
-        return self is DoxygenDiscussion || self is DoxygenNote || self is DoxygenAbstract
-            || self is DoxygenParameter || self is DoxygenReturns
+/// Whether `markup` is a `ListItemContainer` (`UnorderedList` or `OrderedList`).
+fileprivate func isListItemContainer(_ markup: Markup) -> Bool {
+    switch markup._data.raw.markup.data {
+    case .unorderedList, .orderedList:
+        return true
+    default:
+        return false
     }
+}
+
+fileprivate func isHeading(_ markup: Markup) -> Bool {
+    if case .heading = markup._data.raw.markup.data { return true }
+    return false
+}
+
+fileprivate func isBlockQuote(_ markup: Markup) -> Bool {
+    if case .blockQuote = markup._data.raw.markup.data { return true }
+    return false
+}
+
+fileprivate func isUnorderedList(_ markup: Markup) -> Bool {
+    if case .unorderedList = markup._data.raw.markup.data { return true }
+    return false
+}
+
+fileprivate func isOrderedList(_ markup: Markup) -> Bool {
+    if case .orderedList = markup._data.raw.markup.data { return true }
+    return false
+}
+
+fileprivate func isListItem(_ markup: Markup) -> Bool {
+    if case .listItem = markup._data.raw.markup.data { return true }
+    return false
+}
+
+fileprivate func isBlockDirective(_ markup: Markup) -> Bool {
+    if case .blockDirective = markup._data.raw.markup.data { return true }
+    return false
+}
+
+fileprivate func asListItem(_ markup: Markup?) -> ListItem? {
+    guard let markup, case .listItem = markup._data.raw.markup.data else { return nil }
+    return ListItem(markup._data)
 }
 
 fileprivate extension String {
     /// This string, split by newline characters, dropping leading and trailing lines that are empty.
     var trimmedLineSegments: ArraySlice<Substring> {
-        var splitLines = split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)[...].drop { $0.isEmpty }
+        var splitLines = split(omittingEmptySubsequences: false, whereSeparator: { $0.isNewline })[...].drop { $0.isEmpty }
         while let lastLine = splitLines.last, lastLine.isEmpty {
             splitLines = splitLines.dropLast()
         }
@@ -457,21 +505,21 @@ public struct MarkupFormatter: MarkupWalker {
         var prefix = formattingOptions.customLinePrefix
         var unorderedListCount = 0
         var orderedListCount = 0
-        for element in element.parentalChain {
-            if element is BlockQuote {
+        for element in parentalChain(of: element) {
+            if isBlockQuote(element) {
                 prefix += "> "
-            } else if element is UnorderedList {
+            } else if isUnorderedList(element) {
                 if unorderedListCount > 0 {
                     prefix += "  "
                 }
                 unorderedListCount += 1
-            } else if element is OrderedList {
+            } else if isOrderedList(element) {
                 if orderedListCount > 0 {
                     prefix += "   "
                 }
                 orderedListCount += 1
-            } else if !(element is ListItem),
-                let parentListItem = element.parent as? ListItem {
+            } else if !isListItem(element),
+                let parentListItem = asListItem(element.parent) {
                 /*
                  Align contents with list item markers.
 
@@ -488,14 +536,14 @@ public struct MarkupFormatter: MarkupWalker {
                        Second line, aligned.
                  */
 
-                if parentListItem.parent is UnorderedList {
+                if let p = parentListItem.parent, isUnorderedList(p) {
                     // Unordered list markers are of fixed length.
                     prefix += "  "
                 } else if let numeralPrefix = numeralPrefix(for: parentListItem) {
                     prefix += String(repeating: " ", count: numeralPrefix.count)
                 }
             }
-            if element.parent is BlockDirective {
+            if let p = element.parent, isBlockDirective(p) {
                 prefix += "    "
             }
         }
@@ -547,7 +595,7 @@ public struct MarkupFormatter: MarkupWalker {
 
     /// Get the numeral prefix for a list item if its parent is an ordered list.
     func numeralPrefix(for listItem: ListItem) -> String? {
-        guard listItem.parent is OrderedList else {
+        guard let p = listItem.parent, isOrderedList(p) else {
             return nil
         }
         let numeral: UInt
@@ -593,7 +641,7 @@ public struct MarkupFormatter: MarkupWalker {
         }
 
         // Headings may not have soft breaks.
-        guard element.firstAncestor(where: { $0 is Heading }) == nil else {
+        guard firstAncestor(of: element, where: { isHeading($0) }) == nil else {
             print(string, for: element)
             return
         }
@@ -654,7 +702,7 @@ public struct MarkupFormatter: MarkupWalker {
     // MARK: Formatter Walker Methods
 
     public func defaultVisit(_ markup: Markup) {
-        fatalError("Formatter not implemented for \(type(of: markup))")
+        fatalError("Formatter not implemented for \(markup._data.raw.markup.data)")
     }
 
     public mutating func visitDocument(_ document: Document) {
@@ -711,7 +759,7 @@ public struct MarkupFormatter: MarkupWalker {
 
     public mutating func visitBlockQuote(_ blockQuote: BlockQuote) {
         if let parent = blockQuote.parent {
-            if parent is BlockQuote {
+            if isBlockQuote(parent) {
                 queueNewline()
             } else if blockQuote.indexInParent > 0 {
                 queueNewline()
@@ -723,14 +771,14 @@ public struct MarkupFormatter: MarkupWalker {
     }
 
     mutating public func visitUnorderedList(_ unorderedList: UnorderedList) {
-        if unorderedList.indexInParent > 0 && !(unorderedList.parent?.parent is ListItemContainer) {
+        if unorderedList.indexInParent > 0 && !(unorderedList.parent?.parent.map(isListItemContainer) ?? false) {
             ensurePrecedingNewlineCount(atLeast: 2)
         }
         descendInto(unorderedList)
     }
 
     mutating public func visitOrderedList(_ orderedList: OrderedList) {
-        if orderedList.indexInParent > 0 && !(orderedList.parent?.parent is ListItemContainer) {
+        if orderedList.indexInParent > 0 && !(orderedList.parent?.parent.map(isListItemContainer) ?? false) {
             ensurePrecedingNewlineCount(atLeast: 2)
         }
         descendInto(orderedList)
@@ -758,7 +806,7 @@ public struct MarkupFormatter: MarkupWalker {
             }
         } ?? ""
 
-        if listItem.parent is UnorderedList {
+        if let p = listItem.parent, isUnorderedList(p) {
             print("\(formattingOptions.unorderedListMarker.rawValue) \(checkbox)", for: listItem)
         } else if let numeralPrefix = numeralPrefix(for: listItem) {
             print("\(numeralPrefix)\(checkbox)", for: listItem)
@@ -924,6 +972,12 @@ public struct MarkupFormatter: MarkupWalker {
         if table.indexInParent > 0 {
             ensurePrecedingNewlineCount(atLeast: 2)
         }
+        #if hasFeature(Embedded)
+        // Table rendering relies on `LazyMapSequence<MarkupChildren, Table.Cell>`
+        // and `Table.Row` accessors that perform protocol-typed dynamic casts,
+        // which Embedded Swift forbids. Skip table rendering on Embedded targets.
+        return
+        #else
         // The general strategy is to print each table cell completely
         // independently, measuring each of their dimensions, and then expanding
         // them so that all cells in the same column have the same width
@@ -1113,6 +1167,7 @@ public struct MarkupFormatter: MarkupWalker {
             print("|", for: table.body.child(at: row)!)
             queueNewline()
         }
+        #endif
     }
 
     /// See ``MarkupFormatter/visitTable(_:)-61rlp`` for more information.
@@ -1203,7 +1258,7 @@ public struct MarkupFormatter: MarkupWalker {
     }
 
     private mutating func ensureDoxygenCommandPrecedingNewline(for element: Markup) {
-        guard let previousSibling = element.previousSibling else {
+        guard let previousSibling = previousSibling(of: element) else {
             return
         }
 
@@ -1212,7 +1267,7 @@ public struct MarkupFormatter: MarkupWalker {
             return
         }
 
-        let newlineCount = previousSibling.isDoxygenCommand ? 1 : 2
+        let newlineCount = isDoxygenCommand(previousSibling) ? 1 : 2
         ensurePrecedingNewlineCount(atLeast: newlineCount)
     }
 

--- a/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
@@ -101,7 +101,11 @@ struct MarkupTreeDumper: MarkupWalker {
 
     private mutating func dump(_ markup: Markup, customDescription: String? = nil) {
         indent(markup)
+        #if hasFeature(Embedded)
+        result += "\(markup._data.raw.markup.data)"
+        #else
         result += "\(type(of: markup))"
+        #endif
         if options.contains(.printSourceLocations),
             let range = markup.range {
             result += " @\(range.diagnosticDescription(includePath: false))"

--- a/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
@@ -8,12 +8,27 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if canImport(Foundation)
 import Foundation
+#endif
 
 fileprivate extension String {
-    /// A version of `self` with newline "\n" characters escaped as "\\n".
     var newlineEscaped: String {
-        return replacingOccurrences(of: "\n", with: "\\n")
+        var result = ""
+        for char in self {
+            if char == "\n" {
+                result += "\\n"
+            } else {
+                result.append(char)
+            }
+        }
+        return result
+    }
+
+    func _trimmingWhitespace() -> String {
+        guard let start = firstIndex(where: { $0 != " " && $0 != "\t" }),
+              let end = lastIndex(where: { $0 != " " && $0 != "\t" }) else { return "" }
+        return String(self[start...end])
     }
 }
 
@@ -275,7 +290,7 @@ struct MarkupTreeDumper: MarkupWalker {
         if tableCell.rowspan != 1 {
             desc += " rowspan: \(tableCell.rowspan)"
         }
-        desc = desc.trimmingCharacters(in: .whitespaces)
+        desc = desc._trimmingWhitespace()
         if !desc.isEmpty {
             dump(tableCell, customDescription: desc)
         } else {


### PR DESCRIPTION
## Summary

When building `swift-markdown` with Embedded Swift for Wasm, multiple issues occur:
1. Dependency on Foundation doesn't allow building for Embedded Swift, but this dependency is not required for most Embedded Swift use cases
2. Recursive generics with `ManagedBuffer` case compiler hangs, which should emit error diagnostics instead, fixed in https://github.com/swiftlang/swift/pull/88296

## Dependencies

https://github.com/swiftlang/swift/pull/88296 is not a strict dependency, since it will only cause the build of `main` to fail instead of hang. We're working around the use of recursive `ManagedBuffer` when building for Embedded Swift altogether in this PR.

## Testing

Existing non-embedded builds test suite passes. Since Swift Testing doesn't support Embedded Swift yet, this configuration is verified manually.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
