### PR TITLE
update dependencies for 6.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
-        .package(url: "https://github.com/swiftlang/swift-cmark.git", branch: "gfm"),
+        .package(url: "https://github.com/swiftlang/swift-cmark.git", branch: "release/6.4.x"),
     ]
     
     // SwiftPM command plugins are only supported by Swift version 5.6 and later.

--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -47,7 +47,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
-        .package(url: "https://github.com/swiftlang/swift-cmark.git", branch: "gfm"),
+        .package(url: "https://github.com/swiftlang/swift-cmark.git", branch: "release/6.4.x"),
     ]
     
     // SwiftPM command plugins are only supported by Swift version 5.6 and later.


### PR DESCRIPTION
Resubmitting this because in #266 i accidentally targeted `main` instead of `release/6.4.x` 🤦‍♀️ Now it's targeting the correct release branch.

- **Explanation**: Update Swift-Markdown's dependency on swift-cmark to point to its `release/6.4.x` branch.
- **Scope**: Correctness update so that dependency code does not diverge unexpectedly.
- **Issues**: None
- **Original PRs**: None
- **Risk**: None. The `release/6.4.x` and `gfm` branches on swift-cmark are currently identical.
- **Testing**: Automated tests pass. There should be no change in functionality.
- **Reviewers**: @franklinsch as backup branch manager