### PR TITLE
Harden HTMLFormatter output escaping

### DIFF
--- a/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
@@ -10,6 +10,49 @@
 
 import Foundation
 
+private extension String {
+    var escapingHTML: String {
+        var escaped = ""
+        escaped.reserveCapacity(count)
+
+        for character in self {
+            switch character {
+            case "&": escaped += "&amp;"
+            case "<": escaped += "&lt;"
+            case ">": escaped += "&gt;"
+            case "\"": escaped += "&quot;"
+            case "'": escaped += "&#39;"
+            default: escaped.append(character)
+            }
+        }
+
+        return escaped
+    }
+
+    var safeHTMLURL: String? {
+        let leadingControlsAndWhitespace = CharacterSet.controlCharacters.union(.whitespacesAndNewlines)
+        let normalized = trimmingCharacters(in: leadingControlsAndWhitespace).lowercased()
+
+        if normalized.hasPrefix("data:image/png")
+            || normalized.hasPrefix("data:image/gif")
+            || normalized.hasPrefix("data:image/jpeg")
+            || normalized.hasPrefix("data:image/webp")
+        {
+            return escapingHTML
+        }
+
+        if normalized.hasPrefix("javascript:")
+            || normalized.hasPrefix("vbscript:")
+            || normalized.hasPrefix("file:")
+            || normalized.hasPrefix("data:")
+        {
+            return nil
+        }
+
+        return escapingHTML
+    }
+}
+
 /// Options given to the ``HTMLFormatter``.
 public struct HTMLFormatterOptions: OptionSet {
     public var rawValue: UInt
@@ -82,15 +125,15 @@ public struct HTMLFormatter: MarkupWalker {
     public mutating func visitCodeBlock(_ codeBlock: CodeBlock) -> () {
         let languageAttr: String
         if let language = codeBlock.language {
-            languageAttr = " class=\"language-\(language)\""
+            languageAttr = " class=\"language-\(language.escapingHTML)\""
         } else {
             languageAttr = ""
         }
-        result += "<pre><code\(languageAttr)>\(codeBlock.code)</code></pre>\n"
+        result += "<pre><code\(languageAttr)>\(codeBlock.code.escapingHTML)</code></pre>\n"
     }
 
     public mutating func visitHeading(_ heading: Heading) -> () {
-        result += "<h\(heading.level)>\(heading.plainText)</h\(heading.level)>\n"
+        result += "<h\(heading.level)>\(heading.plainText.escapingHTML)</h\(heading.level)>\n"
     }
 
     public mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) -> () {
@@ -222,7 +265,7 @@ public struct HTMLFormatter: MarkupWalker {
     }
 
     public mutating func visitInlineCode(_ inlineCode: InlineCode) -> () {
-        result += "<code>\(inlineCode.code)</code>"
+        result += "<code>\(inlineCode.code.escapingHTML)</code>"
     }
 
     public mutating func visitEmphasis(_ emphasis: Emphasis) -> () {
@@ -236,12 +279,12 @@ public struct HTMLFormatter: MarkupWalker {
     public mutating func visitImage(_ image: Image) -> () {
         result += "<img"
 
-        if let source = image.source, !source.isEmpty {
-            result += " src=\"\(source)\""
+        if let source = image.source, !source.isEmpty, let safeSource = source.safeHTMLURL {
+            result += " src=\"\(safeSource)\""
         }
 
         if let title = image.title, !title.isEmpty {
-            result += " title=\"\(title)\""
+            result += " title=\"\(title.escapingHTML)\""
         }
 
         result += " />"
@@ -261,8 +304,8 @@ public struct HTMLFormatter: MarkupWalker {
 
     public mutating func visitLink(_ link: Link) -> () {
         result += "<a"
-        if let destination = link.destination {
-            result += " href=\"\(destination)\""
+        if let destination = link.destination, let safeDestination = destination.safeHTMLURL {
+            result += " href=\"\(safeDestination)\""
         }
         result += ">"
 
@@ -272,7 +315,7 @@ public struct HTMLFormatter: MarkupWalker {
     }
 
     public mutating func visitText(_ text: Text) -> () {
-        result += text.string
+        result += text.string.escapingHTML
     }
 
     public mutating func visitStrikethrough(_ strikethrough: Strikethrough) -> () {
@@ -281,12 +324,12 @@ public struct HTMLFormatter: MarkupWalker {
 
     public mutating func visitSymbolLink(_ symbolLink: SymbolLink) -> () {
         if let destination = symbolLink.destination {
-            result += "<code>\(destination)</code>"
+            result += "<code>\(destination.escapingHTML)</code>"
         }
     }
 
     public mutating func visitInlineAttributes(_ attributes: InlineAttributes) -> () {
-        result += "<span data-attributes=\"\(attributes.attributes.replacingOccurrences(of: "\"", with: "\\\""))\""
+        result += "<span data-attributes=\"\(attributes.attributes.escapingHTML)\""
 
         let wrappedAttributes = "{\(attributes.attributes)}"
         if options.contains(.parseInlineAttributeClass),
@@ -312,7 +355,7 @@ public struct HTMLFormatter: MarkupWalker {
 
             let parsedAttributes = try? decoder.decode(ParsedAttributes.self, from: attributesData)
             if let parsedAttributes = parsedAttributes {
-                result += " class=\"\(parsedAttributes.class)\""
+                result += " class=\"\(parsedAttributes.class.escapingHTML)\""
             }
         }
 

--- a/Tests/MarkdownTests/Visitors/HTMLFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/HTMLFormatterTests.swift
@@ -90,6 +90,31 @@ final class HTMLFormatterTests: XCTestCase {
         XCTAssertEqual(HTMLFormatter.format(inputText, options: [.parseAsides]), expectedOutput)
     }
 
+    func testEscapesGeneratedHTML() {
+        let inputText = #"""
+        # A < B & C
+
+        Here is `x < y` and [link](javascript:alert(1)) and [ok](https://example.com?a="b"&c=<d>).
+
+        ![img](javascript:alert(1) "bad <title>")
+
+        ```swift
+        if x < y { print("&") }
+        ```
+        """#
+
+        let expectedOutput = """
+        <h1>A &lt; B &amp; C</h1>
+        <p>Here is <code>x &lt; y</code> and <a>link</a> and <a href=\"https://example.com?a=&quot;b&quot;&amp;c=&lt;d&gt;\">ok</a>.</p>
+        <p><img title=\"bad &lt;title&gt;\" /></p>
+        <pre><code class=\"language-swift\">if x &lt; y { print(&quot;&amp;&quot;) }
+        </code></pre>
+
+        """
+
+        XCTAssertEqual(HTMLFormatter.format(inputText), expectedOutput)
+    }
+
     // JSON5 parsing (which allows property names without quotes) is available in Apple Foundation,
     // or in Swift Foundation starting in Swift 6.0
     #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS) || compiler(>=6.0)
@@ -112,7 +137,7 @@ final class HTMLFormatterTests: XCTestCase {
 
         do {
             let expectedOutput = """
-            <p><span data-attributes="class: \\"fancy\\"">formatted text</span></p>
+            <p><span data-attributes="class: &quot;fancy&quot;">formatted text</span></p>
 
             """
 
@@ -124,7 +149,7 @@ final class HTMLFormatterTests: XCTestCase {
 
         do {
             let expectedOutput = """
-            <p><span data-attributes="class: \\"fancy\\"" class="fancy">formatted text</span></p>
+            <p><span data-attributes="class: &quot;fancy&quot;" class="fancy">formatted text</span></p>
 
             """
 
@@ -144,7 +169,7 @@ final class HTMLFormatterTests: XCTestCase {
 
         do {
             let expectedOutput = """
-            <p><span data-attributes="\\"class\\": \\"fancy\\"">formatted text</span></p>
+            <p><span data-attributes="&quot;class&quot;: &quot;fancy&quot;">formatted text</span></p>
 
             """
 
@@ -156,7 +181,7 @@ final class HTMLFormatterTests: XCTestCase {
 
         do {
             let expectedOutput = """
-            <p><span data-attributes="\\"class\\": \\"fancy\\"" class="fancy">formatted text</span></p>
+            <p><span data-attributes="&quot;class&quot;: &quot;fancy&quot;" class="fancy">formatted text</span></p>
 
             """
 


### PR DESCRIPTION
## Summary
- escape generated HTML text and attribute values in HTMLFormatter
- omit dangerous href/src protocols such as javascript:, vbscript:, file:, and unsafe data: URLs
- add coverage for escaped text, code, links, images, and inline attributes

## Why
HTMLFormatter previously interpolated parsed Markdown text, code, link destinations, image sources, titles, and inline attributes directly into generated HTML. Rendering untrusted Markdown through this formatter could produce malformed HTML or scriptable output through generated attributes/URLs.

Raw HTML nodes are still emitted as raw HTML to preserve the formatter's existing documented behavior for HTMLBlock and InlineHTML.

## Testing
- git diff --check
- Local Swift tests were not run because Swift is not installed in this Windows environment.