### PR TITLE
Render inline children of headings in HTMLFormatter

### DIFF
--- a/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
@@ -90,7 +90,9 @@ public struct HTMLFormatter: MarkupWalker {
     }
 
     public mutating func visitHeading(_ heading: Heading) -> () {
-        result += "<h\(heading.level)>\(heading.plainText)</h\(heading.level)>\n"
+        result += "<h\(heading.level)>"
+        descendInto(heading)
+        result += "</h\(heading.level)>\n"
     }
 
     public mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) -> () {

--- a/Tests/MarkdownTests/Visitors/HTMLFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/HTMLFormatterTests.swift
@@ -70,6 +70,24 @@ final class HTMLFormatterTests: XCTestCase {
         XCTAssertEqual(HTMLFormatter.format(everythingDocument), expectedDump)
     }
 
+    func testFormatHeadingWithInlineChildren() {
+        let inputText = """
+        # A *heading* with `code` and [a link](https://example.com)
+
+        ## [0.0.1] - 2014-05-31
+
+        [0.0.1]: https://github.com/olivierlacan/keep-a-changelog/
+        """
+
+        let expectedOutput = """
+        <h1>A <em>heading</em> with <code>code</code> and <a href="https://example.com">a link</a></h1>
+        <h2><a href="https://github.com/olivierlacan/keep-a-changelog/">0.0.1</a> - 2014-05-31</h2>
+
+        """
+
+        XCTAssertEqual(HTMLFormatter.format(inputText), expectedOutput)
+    }
+
     func testFormatAsides() {
         let inputText = """
         > This is a regular block quote.


### PR DESCRIPTION
Bug/issue #: #262

## Summary

`HTMLFormatter.visitHeading` rendered a heading as `heading.plainText`, which flattens inline markup down to text. Any inline children of a heading were dropped from the HTML output: links lost their `<a>` tag, emphasis lost `<em>`, inline code lost `<code>` (and showed literal backticks), and so on.

For example:

```md
## [0.0.1] - 2014-05-31

[0.0.1]: https://github.com/olivierlacan/keep-a-changelog/
```

previously rendered as `<h2>0.0.1 - 2014-05-31</h2>`, silently discarding the link, even though the parsed `Document` contains it.

Every other block element (`visitParagraph`, `visitListItem`, `visitTableCell`, etc.) already walks its children with `descendInto`, so the inline visitors produce the right HTML. This change does the same for headings, which also matches how cmark renders inline content inside headings.

After the change the example renders as:

```html
<h2><a href="https://github.com/olivierlacan/keep-a-changelog/">0.0.1</a> - 2014-05-31</h2>
```

Plain-text headings are unaffected: `# Header` still renders as `<h1>Header</h1>`.

## Testing

Added `testFormatHeadingWithInlineChildren` covering a heading with emphasis, inline code, and a link, plus a reference-style link in a heading. The existing `testFormatEverything` (whose fixture has a plain-text heading) continues to pass unchanged.

Steps:
1. `swift test --filter HTMLFormatterTests`
2. Full suite: `swift test` (300 tests pass locally).

## Checklist

- [x] Added tests
- [x] Ran the test suite and it succeeded
- [ ] Updated documentation if necessary (no documented behavior changes)
