### PR TITLE
Print at least one dash for empty unaligned table columns

### DIFF
--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -998,7 +998,7 @@ public struct MarkupFormatter: MarkupWalker {
         /// The final widths of each column in characters.
         var finalColumnWidths = columnAlignments.map { alignment -> Int in
             guard let alignment = alignment else {
-                return 0
+                return 1
             }
             switch alignment {
             case .left,

--- a/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
@@ -1467,6 +1467,21 @@ class MarkupFormatterTableTests: XCTestCase {
         XCTAssertEqual(expected, formatted)
     }
 
+    func testEmptyUnalignedColumnPrintsValidDelimiter() {
+        let head = Table.Head(Table.Cell(Text("A")), Table.Cell())
+        let body = Table.Body(Table.Row(Table.Cell(Text("1")), Table.Cell()))
+        let document = Document(Table(header: head, body: body))
+
+        let expected = """
+        |A| |
+        |-|-|
+        |1| |
+        """
+        let formatted = document.format()
+        XCTAssertEqual(expected, formatted)
+        XCTAssertTrue(document.hasSameStructure(as: Document(parsing: formatted)))
+    }
+
     func testRoundTripStructure() {
         let source = """
         |*A*|**B**|~C~|


### PR DESCRIPTION
## Summary
  
`MarkupFormatter` (behind `Markup.format()`) prints an **empty delimiter cell** (`||`) for any table column that has no alignment and no content. But an empty delimiter cell is invalid GFM — every delimiter cell must contain at least one `-`.

  ## Dependencies

  None.

## Testing

The fix is covered by a new unit test; no manual setup is required.
  
Steps:
1.  The new test `testEmptyUnalignedColumnPrintsValidDelimiter`

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary — no public API or documented behavior changed, so no docs update needed.