### PR TITLE
Fix a crash when the aside tag includes an en-dash and has no text afyer the tag-separator

### DIFF
--- a/Sources/Markdown/Interpretive Nodes/Aside.swift
+++ b/Sources/Markdown/Interpretive Nodes/Aside.swift
@@ -230,7 +230,7 @@ extension BlockQuote {
         }).count
         let textRange: SourceRange? = initialText.range.map({ originalRange in
             var newStart = originalRange.lowerBound
-            newStart.column += shiftCount
+            newStart.column = min(newStart.column + shiftCount, originalRange.upperBound.column)
             return newStart..<originalRange.upperBound
         })
 

--- a/Tests/MarkdownTests/Interpretive Nodes/AsideTests.swift
+++ b/Tests/MarkdownTests/Interpretive Nodes/AsideTests.swift
@@ -216,6 +216,38 @@ class AsideTests: XCTestCase {
 
         XCTAssertEqual(expectedRootDump, aside.content[0].root.debugDescription(options: .printSourceLocations))
     }
+    
+    func testDoesNotCrashParsingTagWithEnDashAndListItemContent() throws {
+        let enDash = "–"
+        let emDash = "—"
+        
+        for (dashMarkup, expectedColumn, formattedDash) in [
+            ("-",   18, "-"),
+            ("--",  19, enDash),
+            ("---", 20, emDash),
+            
+            (enDash, 20, enDash), // The unicode en-dash character is 3 UTF-8 bytes
+            (emDash, 20, emDash), // The unicode em-dash character is 3 UTF-8 bytes
+        ]{
+            try assertAside(
+                source: """
+                > Before \(dashMarkup) after:
+                > - All other content is inside unordered list
+                """,
+                conversionStrategy: .tagNotRequired,
+                expectedKind: try XCTUnwrap(.init(rawValue: "Before \(formattedDash) after")),
+                expectedRootDump: """
+                Document @/path/to/some-file.md:1:1-/path/to/some-file.md:2:47
+                └─ BlockQuote @/path/to/some-file.md:1:1-/path/to/some-file.md:2:47
+                   ├─ Paragraph @/path/to/some-file.md:1:3-/path/to/some-file.md:1:\(expectedColumn)
+                   │  └─ Text @/path/to/some-file.md:1:\(expectedColumn) ""
+                   └─ UnorderedList @/path/to/some-file.md:2:3-/path/to/some-file.md:2:47
+                      └─ ListItem @/path/to/some-file.md:2:3-/path/to/some-file.md:2:47
+                         └─ Paragraph @/path/to/some-file.md:2:5-/path/to/some-file.md:2:47
+                            └─ Text @/path/to/some-file.md:2:5-/path/to/some-file.md:2:47 "All other content is inside unordered list"
+                """)
+        }
+    }
 
     func assertAside(source: String, conversionStrategy: Aside.TagRequirement, expectedKind: Aside.Kind, expectedRootDump: String, file: StaticString = #file, line: UInt = #line) throws {
         let fakeFileLocation = URL(fileURLWithPath: "/path/to/some-file.md")

--- a/Tests/MarkdownTests/Interpretive Nodes/AsideTests.swift
+++ b/Tests/MarkdownTests/Interpretive Nodes/AsideTests.swift
@@ -218,8 +218,8 @@ class AsideTests: XCTestCase {
     }
     
     func testDoesNotCrashParsingTagWithEnDashAndListItemContent() throws {
-        let enDash = "–"
-        let emDash = "—"
+        let enDash = "\u{2013}"
+        let emDash = "\u{2014}"
         
         for (dashMarkup, expectedColumn, formattedDash) in [
             ("-",   18, "-"),


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://178409822

## Summary

This fixes a crash when an aside tag contains `--` or `---` _and_ has no further _text_ after then tag separator (`:`).

For example, this markup crashes
```md
> Before -- after:
> - Some list item
```

but this modified example doesn't because the tag includes a hyphen instead of a en-dash:
```md
> Before - after:
> - Some list item
```

and this other modified example doesn't because there is more text after the tag separator (`:`)
```md
> Before - after: some text
> - Some list item
```

## Dependencies

None.

## Testing

Parse markup like 
```md
> Before -- after:
> - Some list item
```
or 
```md
> Before --- after:
> - Some list item
```
as an aside. It shouldn't crash with a `Range requires lowerBound <= upperBound` failure.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
