### PR TITLE
[6.4] Fix a crash when the aside tag includes an en-dash and has no text after the tag-separator

### DIFF
--- a/Sources/Markdown/Interpretive Nodes/Aside.swift
+++ b/Sources/Markdown/Interpretive Nodes/Aside.swift
@@ -230,7 +230,7 @@ extension BlockQuote {
         }).count
         let textRange: SourceRange? = initialText.range.map({ originalRange in
             var newStart = originalRange.lowerBound
-            newStart.column += shiftCount
+            newStart.column = min(newStart.column + shiftCount, originalRange.upperBound.column)
             return newStart..<originalRange.upperBound
         })
 

--- a/Tests/MarkdownTests/Interpretive Nodes/AsideTests.swift
+++ b/Tests/MarkdownTests/Interpretive Nodes/AsideTests.swift
@@ -216,6 +216,38 @@ class AsideTests: XCTestCase {
 
         XCTAssertEqual(expectedRootDump, aside.content[0].root.debugDescription(options: .printSourceLocations))
     }
+    
+    func testDoesNotCrashParsingTagWithEnDashAndListItemContent() throws {
+        let enDash = "\u{2013}"
+        let emDash = "\u{2014}"
+        
+        for (dashMarkup, expectedColumn, formattedDash) in [
+            ("-",   18, "-"),
+            ("--",  19, enDash),
+            ("---", 20, emDash),
+            
+            (enDash, 20, enDash), // The unicode en-dash character is 3 UTF-8 bytes
+            (emDash, 20, emDash), // The unicode em-dash character is 3 UTF-8 bytes
+        ]{
+            try assertAside(
+                source: """
+                > Before \(dashMarkup) after:
+                > - All other content is inside unordered list
+                """,
+                conversionStrategy: .tagNotRequired,
+                expectedKind: try XCTUnwrap(.init(rawValue: "Before \(formattedDash) after")),
+                expectedRootDump: """
+                Document @/path/to/some-file.md:1:1-/path/to/some-file.md:2:47
+                └─ BlockQuote @/path/to/some-file.md:1:1-/path/to/some-file.md:2:47
+                   ├─ Paragraph @/path/to/some-file.md:1:3-/path/to/some-file.md:1:\(expectedColumn)
+                   │  └─ Text @/path/to/some-file.md:1:\(expectedColumn) ""
+                   └─ UnorderedList @/path/to/some-file.md:2:3-/path/to/some-file.md:2:47
+                      └─ ListItem @/path/to/some-file.md:2:3-/path/to/some-file.md:2:47
+                         └─ Paragraph @/path/to/some-file.md:2:5-/path/to/some-file.md:2:47
+                            └─ Text @/path/to/some-file.md:2:5-/path/to/some-file.md:2:47 "All other content is inside unordered list"
+                """)
+        }
+    }
 
     func assertAside(source: String, conversionStrategy: Aside.TagRequirement, expectedKind: Aside.Kind, expectedRootDump: String, file: StaticString = #file, line: UInt = #line) throws {
         let fakeFileLocation = URL(fileURLWithPath: "/path/to/some-file.md")


### PR DESCRIPTION
- **Explanation**: Fix a crash when the aside tag includes an en-dash and has no text after the tag-separator
- **Scope**: Resolves an edge case crash when an aside tag includes and en-dash, written as two hyphens (`--`), and the tag has no _text_ after the tag separator (`:`)—but instead has an image, unordered list, etc.
- **Issues**: rdar://178409822
- **Original PRs**: #272
- **Risk**: Low. Isolated bounds in the computation of the aside's tag range and remaining text range.
- **Testing**: See testing notes on #272
- **Reviewers**: @snprajwal 