### PR TITLE
Escape HTML special characters in HTMLFormatter

### DIFF
--- a/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
@@ -264,9 +264,6 @@ public struct HTMLFormatter: MarkupWalker {
         if let destination = link.destination {
             result += " href=\"\(destination)\""
         }
-        if let title = link.title, !title.isEmpty {
-            result += " title=\"\(title)\""
-        }
         result += ">"
 
         descendInto(link)
@@ -331,7 +328,5 @@ private extension String {
             .replacingOccurrences(of: "&", with: "&amp;")
             .replacingOccurrences(of: "<", with: "&lt;")
             .replacingOccurrences(of: ">", with: "&gt;")
-            .replacingOccurrences(of: "\"", with: "&quot;")
-            .replacingOccurrences(of: "'", with: "&#39;")
     }
 }

--- a/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
@@ -86,7 +86,7 @@ public struct HTMLFormatter: MarkupWalker {
         } else {
             languageAttr = ""
         }
-        result += "<pre><code\(languageAttr)>\(codeBlock.code)</code></pre>\n"
+        result += "<pre><code\(languageAttr)>\(codeBlock.code.htmlEscaped())</code></pre>\n"
     }
 
     public mutating func visitHeading(_ heading: Heading) -> () {
@@ -222,7 +222,7 @@ public struct HTMLFormatter: MarkupWalker {
     }
 
     public mutating func visitInlineCode(_ inlineCode: InlineCode) -> () {
-        result += "<code>\(inlineCode.code)</code>"
+        result += "<code>\(inlineCode.code.htmlEscaped())</code>"
     }
 
     public mutating func visitEmphasis(_ emphasis: Emphasis) -> () {
@@ -264,6 +264,9 @@ public struct HTMLFormatter: MarkupWalker {
         if let destination = link.destination {
             result += " href=\"\(destination)\""
         }
+        if let title = link.title, !title.isEmpty {
+            result += " title=\"\(title)\""
+        }
         result += ">"
 
         descendInto(link)
@@ -272,7 +275,7 @@ public struct HTMLFormatter: MarkupWalker {
     }
 
     public mutating func visitText(_ text: Text) -> () {
-        result += text.string
+        result += text.string.htmlEscaped()
     }
 
     public mutating func visitStrikethrough(_ strikethrough: Strikethrough) -> () {
@@ -319,5 +322,16 @@ public struct HTMLFormatter: MarkupWalker {
         result += ">"
         descendInto(attributes)
         result += "</span>"
+    }
+}
+
+private extension String {
+    func htmlEscaped() -> String {
+        return self
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
     }
 }

--- a/Tests/MarkdownTests/Visitors/HTMLFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/HTMLFormatterTests.swift
@@ -316,4 +316,44 @@ final class HTMLFormatterTests: XCTestCase {
             XCTAssertEqual(HTMLFormatter.format(inputText), expectedOutput)
         }
     }
+    
+    func testHtmlEscaping() {
+      do {
+        let inputText = "&lt;key&gt;"
+
+        let expectedOutput = """
+          <p>&lt;key&gt;</p>
+
+          """
+
+        XCTAssertEqual(HTMLFormatter.format(inputText), expectedOutput)
+      }
+
+      do {
+        let inputText = "`<key>`"
+
+        let expectedOutput = """
+          <p><code>&lt;key&gt;</code></p>
+
+          """
+
+        XCTAssertEqual(HTMLFormatter.format(inputText), expectedOutput)
+      }
+
+      do {
+        let inputText = """
+          ```
+          <key>
+          ```
+          """
+
+        let expectedOutput = """
+          <pre><code>&lt;key&gt;
+          </code></pre>
+
+          """
+
+        XCTAssertEqual(HTMLFormatter.format(inputText), expectedOutput)
+      }
+    }
 }

--- a/Tests/MarkdownTests/Visitors/HTMLFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/HTMLFormatterTests.swift
@@ -319,6 +319,9 @@ final class HTMLFormatterTests: XCTestCase {
     
     func testHtmlEscaping() {
       do {
+        // The parser decodes `&lt;key&gt;` into `<key>` in the AST.
+        // The formatter re-escapes it when generating HTML, so the output is
+        // `&lt;key&gt;` rather than `&amp;lt;key&amp;gt;`.
         let inputText = "&lt;key&gt;"
 
         let expectedOutput = """


### PR DESCRIPTION
Bug/issue #, if applicable: Fixes #264

## Summary

The HTML formatter previously emitted text, inline code, and code block contents without escaping HTML special characters. As a result, markdown containing escaped entities such as:
```markdown
&lt;key&gt;
```
could be rendered as HTML that browsers interpret as an actual tag rather than displaying the text <key>. This change escapes &, <, and > when rendering text, inline code, and code block contents in HTMLFormatter. Raw HTML nodes (HTMLBlock and InlineHTML) continue to be emitted unchanged.

## Dependencies

N/A

## Testing

Regression tests have been added to verify correct rendering for:

- Regular text containing escaped HTML entities
- Inline code containing angle brackets
- Code blocks containing angle brackets

Steps:
1. Build and run the test suite:
2. Verify the new regression tests pass.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary