### PR TITLE
Replace recursive CommonMark conversion with iterative traversal

### DIFF
--- a/Sources/Markdown/Base/RawMarkup.swift
+++ b/Sources/Markdown/Base/RawMarkup.swift
@@ -162,8 +162,35 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
     }
 
     deinit {
-        return self.withUnsafeMutablePointerToElements {
-            $0.deinitialize(count: header.childCount)
+        var workStack = [RawMarkup]()
+        
+        self.withUnsafeMutablePointerToElements { elements in
+            for i in 0..<header.childCount {
+                workStack.append(elements[i])
+            }
+            elements.deinitialize(count: header.childCount)
+        }
+        
+        while var node = workStack.popLast() {
+            guard isKnownUniquelyReferenced(&node) else {
+                continue
+            }
+            
+            node.withUnsafeMutablePointerToElements { elements in
+                for i in 0..<node.header.childCount {
+                    workStack.append(elements[i])
+                }
+                elements.deinitialize(count: node.header.childCount)
+            }
+            
+            node.withUnsafeMutablePointerToHeader { headerPtr in
+                headerPtr.pointee = RawMarkupHeader(
+                    data: node.header.data,
+                    childCount: 0,
+                    subtreeCount: node.header.subtreeCount,
+                    parsedRange: node.header.parsedRange
+                )
+            }
         }
     }
 

--- a/Sources/Markdown/Base/RawMarkup.swift
+++ b/Sources/Markdown/Base/RawMarkup.swift
@@ -165,6 +165,12 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
         var workStack = [RawMarkup]()
         
         self.withUnsafeMutablePointerToElements { elements in
+            
+            // Retain children on a heap-allocated work stack before
+            // deinitializing the tail allocation. Without this, releasing a
+            // uniquely referenced child would immediately enter its deinit,
+            // recursively cascading through the tree and potentially
+            // overflowing the call stack for deeply nested markup.
             for i in 0..<header.childCount {
                 workStack.append(elements[i])
             }

--- a/Sources/Markdown/Parser/CommonMarkConverter.swift
+++ b/Sources/Markdown/Parser/CommonMarkConverter.swift
@@ -212,22 +212,6 @@ struct MarkupParser {
         return String(cString: rawText)
     }
     
-    private static func convertThematicBreak(parsedRange: SourceRange?) -> RawMarkup {
-        return .thematicBreak(parsedRange: parsedRange)
-    }
-
-    private static func convertText(node: UnsafeMutablePointer<cmark_node>!, parsedRange: SourceRange?) -> RawMarkup {
-        return .text(parsedRange: parsedRange, string: getLiteralContent(node: node))
-    }
-
-    private static func convertSoftBreak(parsedRange: SourceRange?) -> RawMarkup {
-        return .softBreak(parsedRange: parsedRange)
-    }
-
-    private static func convertLineBreak(parsedRange: SourceRange?) -> RawMarkup {
-        return .lineBreak(parsedRange: parsedRange)
-    }
-    
     /// Converts a leaf cmark node directly into its corresponding `RawMarkup` representation.
     private static func createLeaf(nodeType: CommonMarkNodeType, node: UnsafeMutablePointer<cmark_node>, parsedRange: SourceRange?, state: MarkupConverterState) -> RawMarkup {
         precondition(state.event == CMARK_EVENT_ENTER, "Expected ENTER event when creating a leaf node.")
@@ -240,13 +224,13 @@ struct MarkupParser {
         case .htmlBlock:
             return .htmlBlock(parsedRange: parsedRange, html: getLiteralContent(node: node))
         case .thematicBreak:
-            return convertThematicBreak(parsedRange: parsedRange)
+            return .thematicBreak(parsedRange: parsedRange)
         case .text:
-            return convertText(node: node, parsedRange: parsedRange)
+            return .text(parsedRange: parsedRange, string: getLiteralContent(node: node))
         case .softBreak:
-            return convertSoftBreak(parsedRange: parsedRange)
+            return .softBreak(parsedRange: parsedRange)
         case .lineBreak:
-            return convertLineBreak(parsedRange: parsedRange)
+            return .lineBreak(parsedRange: parsedRange)
         case .code:
             let literalContent = getLiteralContent(node: node)
             if state.options.contains(.parseSymbolLinks), cmark_node_get_backtick_count(node) > 1 {

--- a/Sources/Markdown/Parser/CommonMarkConverter.swift
+++ b/Sources/Markdown/Parser/CommonMarkConverter.swift
@@ -211,39 +211,105 @@ struct MarkupParser {
         }
         return String(cString: rawText)
     }
-    
+
+    private static func convertCodeBlock(_ state: MarkupConverterState) -> RawMarkup {
+        precondition(state.event == CMARK_EVENT_ENTER)
+        precondition(state.nodeType == .codeBlock)
+        let parsedRange = state.range(state.node)
+        let language = String(cString: cmark_node_get_fence_info(state.node))
+        let code = getLiteralContent(node: state.node)
+        return .codeBlock(parsedRange: parsedRange, code: code, language: language.isEmpty ? nil : language)
+    }
+
+    private static func convertHTMLBlock(_ state: MarkupConverterState) -> RawMarkup {
+        precondition(state.event == CMARK_EVENT_ENTER)
+        precondition(state.nodeType == .htmlBlock)
+        let parsedRange = state.range(state.node)
+        let html = getLiteralContent(node: state.node)
+        return .htmlBlock(parsedRange: parsedRange, html: html)
+    }
+
+    private static func convertThematicBreak(_ state: MarkupConverterState) -> RawMarkup {
+        precondition(state.event == CMARK_EVENT_ENTER)
+        precondition(state.nodeType == .thematicBreak)
+        let parsedRange = state.range(state.node)
+        return .thematicBreak(parsedRange: parsedRange)
+    }
+
+    private static func convertText(_ state: MarkupConverterState) -> RawMarkup {
+        precondition(state.event == CMARK_EVENT_ENTER)
+        precondition(state.nodeType == .text)
+        let parsedRange = state.range(state.node)
+        let string = getLiteralContent(node: state.node)
+        return .text(parsedRange: parsedRange, string: string)
+    }
+
+    private static func convertSoftBreak(_ state: MarkupConverterState) -> RawMarkup {
+        precondition(state.event == CMARK_EVENT_ENTER)
+        precondition(state.nodeType == .softBreak)
+        let parsedRange = state.range(state.node)
+        return .softBreak(parsedRange: parsedRange)
+    }
+
+    private static func convertLineBreak(_ state: MarkupConverterState) -> RawMarkup {
+        precondition(state.event == CMARK_EVENT_ENTER)
+        precondition(state.nodeType == .lineBreak)
+        let parsedRange = state.range(state.node)
+        return .lineBreak(parsedRange: parsedRange)
+    }
+
+    private static func convertInlineCode(_ state: MarkupConverterState) -> RawMarkup {
+        precondition(state.event == CMARK_EVENT_ENTER)
+        precondition(state.nodeType == .code)
+        let parsedRange = state.range(state.node)
+        let literalContent = getLiteralContent(node: state.node)
+        if state.options.contains(.parseSymbolLinks),
+           cmark_node_get_backtick_count(state.node) > 1 {
+            return .symbolLink(parsedRange: parsedRange, destination: literalContent)
+        } else {
+            return .inlineCode(parsedRange: parsedRange, code: literalContent)
+        }
+    }
+
+    private static func convertInlineHTML(_ state: MarkupConverterState) -> RawMarkup {
+        precondition(state.event == CMARK_EVENT_ENTER)
+        precondition(state.nodeType == .html)
+        let parsedRange = state.range(state.node)
+        let html = getLiteralContent(node: state.node)
+        return .inlineHTML(parsedRange: parsedRange, html: html)
+    }
+
+    private static func convertCustomInline(_ state: MarkupConverterState) -> RawMarkup {
+        precondition(state.event == CMARK_EVENT_ENTER)
+        precondition(state.nodeType == .customInline)
+        let parsedRange = state.range(state.node)
+        let text = getLiteralContent(node: state.node)
+        return .customInline(parsedRange: parsedRange, text: text)
+    }
+
     /// Converts a leaf cmark node directly into its corresponding `RawMarkup` representation.
-    private static func createLeaf(nodeType: CommonMarkNodeType, node: UnsafeMutablePointer<cmark_node>, parsedRange: SourceRange?, state: MarkupConverterState) -> RawMarkup {
-        precondition(state.event == CMARK_EVENT_ENTER, "Expected ENTER event when creating a leaf node.")
-        precondition(state.nodeType == nodeType, "MarkupConverterState nodeType does not match the leaf being created.")
-        switch nodeType {
+    private static func createLeaf(state: MarkupConverterState) -> RawMarkup {
+        switch state.nodeType {
         case .codeBlock:
-            let language = String(cString: cmark_node_get_fence_info(node))
-            let code = getLiteralContent(node: node)
-            return .codeBlock(parsedRange: parsedRange, code: code, language: language.isEmpty ? nil : language)
+            return convertCodeBlock(state)
         case .htmlBlock:
-            return .htmlBlock(parsedRange: parsedRange, html: getLiteralContent(node: node))
+            return convertHTMLBlock(state)
         case .thematicBreak:
-            return .thematicBreak(parsedRange: parsedRange)
+            return convertThematicBreak(state)
         case .text:
-            return .text(parsedRange: parsedRange, string: getLiteralContent(node: node))
+            return convertText(state)
         case .softBreak:
-            return .softBreak(parsedRange: parsedRange)
+            return convertSoftBreak(state)
         case .lineBreak:
-            return .lineBreak(parsedRange: parsedRange)
+            return convertLineBreak(state)
         case .code:
-            let literalContent = getLiteralContent(node: node)
-            if state.options.contains(.parseSymbolLinks), cmark_node_get_backtick_count(node) > 1 {
-                return .symbolLink(parsedRange: parsedRange, destination: literalContent)
-            } else {
-                return .inlineCode(parsedRange: parsedRange, code: literalContent)
-            }
+            return convertInlineCode(state)
         case .html:
-            return .inlineHTML(parsedRange: parsedRange, html: getLiteralContent(node: node))
+            return convertInlineHTML(state)
         case .customInline:
-            return .customInline(parsedRange: parsedRange, text: getLiteralContent(node: node))
+            return convertCustomInline(state)
         default:
-            fatalError("Unhandled leaf node type: \(nodeType)")
+            fatalError("Unhandled leaf node type: \(state.nodeType)")
         }
     }
 
@@ -383,7 +449,7 @@ struct MarkupParser {
 
             if state.event == CMARK_EVENT_ENTER {
                 if nodeType.isLeaf {
-                    let leaf = createLeaf(nodeType: nodeType, node: node, parsedRange: parsedRange, state: state)
+                    let leaf = createLeaf(state: state)
                     precondition(!stack.isEmpty, "Leaf node encountered without a parent document on the stack.")
                     stack[stack.count - 1].children.append(leaf)
                 } else {

--- a/Sources/Markdown/Parser/CommonMarkConverter.swift
+++ b/Sources/Markdown/Parser/CommonMarkConverter.swift
@@ -70,6 +70,21 @@ fileprivate enum CommonMarkNodeType: String {
     case taskListItem = "tasklist"
 }
 
+fileprivate extension CommonMarkNodeType {
+    /// Returns true when a node kind cannot have structural children.
+    ///
+    /// Leaf nodes are converted immediately when their ENTER event is
+    /// encountered and therefore never need a `ParsingFrame`.
+    var isLeaf: Bool {
+        switch self {
+        case .codeBlock, .htmlBlock, .thematicBreak, .text, .softBreak, .lineBreak, .code, .html, .customInline:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
 /// Represents the current state of cmark -> `Markup` conversion.
 fileprivate struct MarkupConverterState {
     fileprivate struct PendingTableBody {
@@ -194,22 +209,27 @@ struct MarkupParser {
         }
         return String(cString: rawText)
     }
+    
+    private static func convertThematicBreak(parsedRange: SourceRange?) -> RawMarkup {
+        return .thematicBreak(parsedRange: parsedRange)
+    }
 
-    /// Returns true when a node kind cannot have structural children.
-    ///
-    /// Leaf nodes are converted immediately when their ENTER event is
-    /// encountered and therefore never need a `ParsingFrame`.
-    private static func isLeaf(_ type: CommonMarkNodeType) -> Bool {
-        switch type {
-        case .codeBlock, .htmlBlock, .thematicBreak, .text, .softBreak, .lineBreak, .code, .html, .customInline:
-            return true
-        default:
-            return false
-        }
+    private static func convertText(node: UnsafeMutablePointer<cmark_node>!, parsedRange: SourceRange?) -> RawMarkup {
+        return .text(parsedRange: parsedRange, string: getLiteralContent(node: node))
+    }
+
+    private static func convertSoftBreak(parsedRange: SourceRange?) -> RawMarkup {
+        return .softBreak(parsedRange: parsedRange)
+    }
+
+    private static func convertLineBreak(parsedRange: SourceRange?) -> RawMarkup {
+        return .lineBreak(parsedRange: parsedRange)
     }
     
     /// Converts a leaf cmark node directly into its corresponding `RawMarkup` representation.
     private static func createLeaf(nodeType: CommonMarkNodeType, node: UnsafeMutablePointer<cmark_node>, parsedRange: SourceRange?, state: MarkupConverterState) -> RawMarkup {
+        precondition(state.event == CMARK_EVENT_ENTER, "Expected ENTER event when creating a leaf node.")
+        precondition(state.nodeType == nodeType, "MarkupConverterState nodeType does not match the leaf being created.")
         switch nodeType {
         case .codeBlock:
             let language = String(cString: cmark_node_get_fence_info(node))
@@ -218,13 +238,13 @@ struct MarkupParser {
         case .htmlBlock:
             return .htmlBlock(parsedRange: parsedRange, html: getLiteralContent(node: node))
         case .thematicBreak:
-            return .thematicBreak(parsedRange: parsedRange)
+            return convertThematicBreak(parsedRange: parsedRange)
         case .text:
-            return .text(parsedRange: parsedRange, string: getLiteralContent(node: node))
+            return convertText(node: node, parsedRange: parsedRange)
         case .softBreak:
-            return .softBreak(parsedRange: parsedRange)
+            return convertSoftBreak(parsedRange: parsedRange)
         case .lineBreak:
-            return .lineBreak(parsedRange: parsedRange)
+            return convertLineBreak(parsedRange: parsedRange)
         case .code:
             let literalContent = getLiteralContent(node: node)
             if state.options.contains(.parseSymbolLinks), cmark_node_get_backtick_count(node) > 1 {
@@ -247,6 +267,8 @@ struct MarkupParser {
     /// At that point all descendant nodes have already been converted and
     /// accumulated in `frame.children`.
     private static func createContainer(frame: ParsingFrame, state: MarkupConverterState) -> RawMarkup {
+        precondition(state.event == CMARK_EVENT_EXIT, "Expected EXIT event when closing a container node.")
+        precondition(state.nodeType == frame.nodeType, "MarkupConverterState nodeType does not match the frame being closed.")
         let node = frame.node
         let children = frame.children
         let parsedRange = frame.parsedRange
@@ -299,7 +321,7 @@ struct MarkupParser {
             let columnCount = Int(cmark_gfm_extensions_get_table_columns(node))
             let columnAlignments = (0..<columnCount).map { column -> Table.ColumnAlignment? in
                 let ascii = cmark_gfm_extensions_get_table_alignments(node)[column]
-                switch Character(UnicodeScalar(ascii)) {
+                switch UnicodeScalar(ascii) {
                 case "l": return .left
                 case "r": return .right
                 case "c": return .center
@@ -318,13 +340,10 @@ struct MarkupParser {
                 header = .tableHead(parsedRange: nil, columns: [])
             }
 
-            let body: RawMarkup
-            if !mutableChildren.isEmpty {
-                let pendingBodyRange = state.pendingTableBody?.range
-                body = .tableBody(parsedRange: pendingBodyRange, rows: mutableChildren)
-            } else {
-                body = .tableBody(parsedRange: nil, rows: [])
+            if mutableChildren.isEmpty {
+                precondition(state.pendingTableBody == nil)
             }
+            let body = RawMarkup.tableBody(parsedRange: state.pendingTableBody?.range, rows: mutableChildren)
             return .table(columnAlignments: columnAlignments, parsedRange: parsedRange, header: header, body: body)
         case .tableHead:
             return .tableHead(parsedRange: parsedRange, columns: children)
@@ -377,7 +396,7 @@ struct MarkupParser {
             let parsedRange = state.range(node)
 
             if state.event == CMARK_EVENT_ENTER {
-                if isLeaf(nodeType) {
+                if nodeType.isLeaf {
                     let leaf = createLeaf(nodeType: nodeType, node: node, parsedRange: parsedRange, state: state)
                     precondition(!stack.isEmpty, "Leaf node encountered without a parent document on the stack.")
                     stack[stack.count - 1].children.append(leaf)
@@ -387,7 +406,7 @@ struct MarkupParser {
                 state = state.next()
                 
             } else if state.event == CMARK_EVENT_EXIT {
-                if isLeaf(nodeType) {
+                if nodeType.isLeaf {
                     state = state.next()
                 } else {
                     let frame = stack.removeLast()

--- a/Sources/Markdown/Parser/CommonMarkConverter.swift
+++ b/Sources/Markdown/Parser/CommonMarkConverter.swift
@@ -202,7 +202,9 @@ struct MarkupParser {
         var children: [RawMarkup] = []
     }
 
-    /// Extracts the literal text payload from a cmark node.
+    /// Returns the raw literal text for a cmark node.
+    ///
+    /// - parameter node: An opaque pointer to a `cmark_node`.
     private static func getLiteralContent(node: UnsafeMutablePointer<cmark_node>!) -> String {
         guard let rawText = cmark_node_get_literal(node) else {
             fatalError("Expected literal content for cmark node but got null pointer")

--- a/Sources/Markdown/Parser/CommonMarkConverter.swift
+++ b/Sources/Markdown/Parser/CommonMarkConverter.swift
@@ -438,7 +438,7 @@ struct MarkupParser {
 
         var stack = [ParsingFrame]()
 
-        while state.event != CMARK_EVENT_DONE && state.event != CMARK_EVENT_NONE {
+        while state.event != CMARK_EVENT_DONE {
             guard let node = state.node else {
                 state = state.next()
                 continue
@@ -458,36 +458,28 @@ struct MarkupParser {
                 state = state.next()
                 
             } else if state.event == CMARK_EVENT_EXIT {
-                if nodeType.isLeaf {
-                    state = state.next()
+                precondition(!nodeType.isLeaf, "cmark iterators should never return EXIT events for leaf nodes.")
+                
+                let frame = stack.removeLast()
+                precondition(frame.node == node)
+                
+                let container = createContainer(frame: frame, state: state)
+                
+                if stack.isEmpty {
+                    precondition(frame.nodeType == .document)
+                    let iterator = state.iterator
+                    
+                    cmark_iter_free(iterator)
+                    cmark_node_free(rawDocument)
+                    cmark_parser_free(parser)
+                    
+                    let data = _MarkupData(AbsoluteRawMarkup(markup: container, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0)))
+                    return makeMarkup(data) as! Document
+                    
                 } else {
-                    let frame = stack.removeLast()
-                    precondition(frame.node == node)
-                    
-                    let container = createContainer(frame: frame, state: state)
-                    
-                    if stack.isEmpty {
-                        precondition(frame.nodeType == .document)
-                        let iterator = state.iterator
-                        
-                        cmark_iter_free(iterator)
-                        cmark_node_free(rawDocument)
-                        cmark_parser_free(parser)
-                        
-                        let data = _MarkupData(AbsoluteRawMarkup(markup: container, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0)))
-                        return makeMarkup(data) as! Document
-                        
-                    } else {
-                        stack[stack.count - 1].children.append(container)
-                        if nodeType == .table {
-                            state = state.next(clearPendingTableBody: true)
-                        } else {
-                            state = state.next()
-                        }
-                    }
+                    stack[stack.count - 1].children.append(container)
+                    state = state.next(clearPendingTableBody: nodeType == .table)
                 }
-            } else {
-                state = state.next()
             }
         }
 

--- a/Sources/Markdown/Parser/CommonMarkConverter.swift
+++ b/Sources/Markdown/Parser/CommonMarkConverter.swift
@@ -70,12 +70,6 @@ fileprivate enum CommonMarkNodeType: String {
     case taskListItem = "tasklist"
 }
 
-/// Represents the result of a cmark conversion: the current `MarkupConverterState` and the resulting converted node.
-fileprivate struct MarkupConversion<Result> {
-    let state: MarkupConverterState
-    let result: Result
-}
-
 /// Represents the current state of cmark -> `Markup` conversion.
 fileprivate struct MarkupConverterState {
     fileprivate struct PendingTableBody {
@@ -135,6 +129,7 @@ fileprivate struct MarkupConverterState {
 
     /// The type of the last parsed cmark node.
     var nodeType: CommonMarkNodeType {
+        guard let node = node else { return .none }
         let typeString = String(cString: cmark_node_get_type_string(node))
         guard let type = CommonMarkNodeType(rawValue: typeString) else {
             fatalError("Unknown cmark node type '\(typeString)' encountered during conversion")
@@ -173,73 +168,26 @@ fileprivate struct MarkupConverterState {
 
 /// Parses markup source and returns a `Markup` node representing the parsed source.
 struct MarkupParser {
-    /// Dispatches into specific conversion methods from every kind of cmark element, returning the resulting `RawMarkup`.
-    private static func convertAnyElement(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-
-        switch state.nodeType {
-        case .document:
-            return convertDocument(state)
-        case .blockQuote:
-            return convertBlockQuote(state)
-        case .list:
-            return convertList(state)
-        case .item:
-            return convertListItem(state)
-        case .codeBlock:
-            return convertCodeBlock(state)
-        case .htmlBlock:
-            return convertHTMLBlock(state)
-        case .customBlock:
-            return convertCustomBlock(state)
-        case .paragraph:
-            return convertParagraph(state)
-        case .heading:
-            return convertHeading(state)
-        case .thematicBreak:
-            return convertThematicBreak(state)
-        case .text:
-            return convertText(state)
-        case .softBreak:
-            return convertSoftBreak(state)
-        case .lineBreak:
-            return convertLineBreak(state)
-        case .code:
-            return convertInlineCode(state)
-        case .html:
-            return convertInlineHTML(state)
-        case .customInline:
-            return convertCustomInline(state)
-        case .emphasis:
-            return convertEmphasis(state)
-        case .strong:
-            return convertStrong(state)
-        case .link:
-            return convertLink(state)
-        case .image:
-            return convertImage(state)
-        case .strikethrough:
-            return convertStrikethrough(state)
-        case .taskListItem:
-            return convertTaskListItem(state)
-        case .table:
-            return convertTable(state)
-        case .tableHead:
-            return convertTableHeader(state)
-        case .tableRow:
-            return convertTableRow(state)
-        case .tableCell:
-            return convertTableCell(state)
-        case .inlineAttributes:
-            return convertInlineAttributes(state)
-        default:
-            fatalError("Unknown cmark node type '\(state.nodeType.rawValue)' encountered during conversion")
-        }
+    
+    /// Represents an active container node while iteratively converting the
+    /// cmark AST into `RawMarkup`.
+    private struct ParsingFrame {
+        
+        /// The underlying cmark node associated with this frame.
+        let node: UnsafeMutablePointer<cmark_node>
+        
+        /// Cached node type to avoid repeated string conversions while the
+        /// frame remains on the work stack.
+        let nodeType: CommonMarkNodeType
+        
+        /// Source range reported by cmark for this node.
+        let parsedRange: SourceRange?
+        
+        /// Converted child nodes accumulated between ENTER and EXIT events.
+        var children: [RawMarkup] = []
     }
 
-    /// Returns the raw literal text for a cmark node.
-    ///
-    /// - parameter node: An opaque pointer to a `cmark_node`.
+    /// Extracts the literal text payload from a cmark node.
     private static func getLiteralContent(node: UnsafeMutablePointer<cmark_node>!) -> String {
         guard let rawText = cmark_node_get_literal(node) else {
             fatalError("Expected literal content for cmark node but got null pointer")
@@ -247,366 +195,152 @@ struct MarkupParser {
         return String(cString: rawText)
     }
 
-    /// Converts the children of the given state's cmark node and return them all.
+    /// Returns true when a node kind cannot have structural children.
     ///
-    /// - parameter originalState: The state containing the node whose children you want to convert.
-    /// - returns: A new conversion containing all of the node's converted children.
-    private static func convertChildren(_ originalState: MarkupConverterState) -> MarkupConversion<[RawMarkup]> {
-        let root = originalState.node
-        var state = originalState.next()
-        var layout = [RawMarkup]()
-
-        while state.node != root && state.event != CMARK_EVENT_EXIT {
-            let conversion = convertAnyElement(state)
-            layout.append(conversion.result)
-            state = conversion.state
-        }
-        return MarkupConversion(state: state, result: layout)
-    }
-
-    private static func convertDocument(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .document)
-        let parsedRange = state.range(state.node)
-        let childConversion = convertChildren(state)
-        precondition(childConversion.state.event == CMARK_EVENT_EXIT)
-        precondition(childConversion.state.node == state.node)
-        return MarkupConversion(state: childConversion.state.next(), result: .document(parsedRange: parsedRange, childConversion.result))
-    }
-
-    private static func convertBlockQuote(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .blockQuote)
-        let parsedRange = state.range(state.node)
-        let childConversion = convertChildren(state)
-        precondition(childConversion.state.node == state.node)
-        precondition(childConversion.state.event == CMARK_EVENT_EXIT)
-        return MarkupConversion(state: childConversion.state.next(), result: .blockQuote(parsedRange: parsedRange, childConversion.result))
-    }
-
-    private static func convertList(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .list)
-        let parsedRange = state.range(state.node)
-        let childConversion = convertChildren(state)
-        precondition(childConversion.state.node == state.node)
-        precondition(childConversion.state.event == CMARK_EVENT_EXIT)
-
-        for child in childConversion.result {
-            guard case .listItem = child.data else {
-                fatalError("Converted cmark list had a node other than RawMarkup.listItem")
-            }
-        }
-
-        switch cmark_node_get_list_type(state.node) {
-        case CMARK_BULLET_LIST:
-            return MarkupConversion(state: childConversion.state.next(), result: .unorderedList(parsedRange: parsedRange, childConversion.result))
-        case CMARK_ORDERED_LIST:
-            let cmarkStart = UInt(cmark_node_get_list_start(state.node))
-            return MarkupConversion(state: childConversion.state.next(), result: .orderedList(parsedRange: parsedRange, childConversion.result, startIndex: cmarkStart))
+    /// Leaf nodes are converted immediately when their ENTER event is
+    /// encountered and therefore never need a `ParsingFrame`.
+    private static func isLeaf(_ type: CommonMarkNodeType) -> Bool {
+        switch type {
+        case .codeBlock, .htmlBlock, .thematicBreak, .text, .softBreak, .lineBreak, .code, .html, .customInline:
+            return true
         default:
-            fatalError("cmark reported a list node but said its list type is CMARK_NO_LIST?")
+            return false
         }
     }
-
-    private static func convertListItem(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .item)
-        let parsedRange = state.range(state.node)
-        let childConversion = convertChildren(state)
-        precondition(childConversion.state.node == state.node)
-        precondition(childConversion.state.event == CMARK_EVENT_EXIT)
-        return MarkupConversion(state: childConversion.state.next(), result: .listItem(checkbox: .none, parsedRange: parsedRange, childConversion.result))
-    }
-
-    private static func convertCodeBlock(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .codeBlock)
-        let parsedRange = state.range(state.node)
-        let language = String(cString: cmark_node_get_fence_info(state.node))
-        let code = getLiteralContent(node: state.node)
-
-        return MarkupConversion(state: state.next(), result: .codeBlock(parsedRange: parsedRange, code: code, language: language.isEmpty ? nil : language))
-    }
-
-    private static func convertHTMLBlock(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .htmlBlock)
-        let parsedRange = state.range(state.node)
-        let html = getLiteralContent(node: state.node)
-        return MarkupConversion(state: state.next(), result: .htmlBlock(parsedRange: parsedRange, html: html))
-    }
-
-    private static func convertCustomBlock(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .customBlock)
-        let parsedRange = state.range(state.node)
-        let childConversion = convertChildren(state)
-        precondition(childConversion.state.node == state.node)
-        precondition(childConversion.state.event == CMARK_EVENT_EXIT)
-        return MarkupConversion(state: childConversion.state.next(), result: .customBlock(parsedRange: parsedRange, childConversion.result))
-    }
-
-    private static func convertParagraph(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .paragraph)
-        let parsedRange = state.range(state.node)
-        let childConversion = convertChildren(state)
-        precondition(childConversion.state.node == state.node)
-        precondition(childConversion.state.event == CMARK_EVENT_EXIT)
-        return MarkupConversion(state: childConversion.state.next(), result: .paragraph(parsedRange: parsedRange, childConversion.result))
-    }
-
-    private static func convertHeading(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .heading)
-        let parsedRange = state.range(state.node)
-        let headingLevel = Int(cmark_node_get_heading_level(state.node))
-        let childConversion = convertChildren(state)
-        precondition(childConversion.state.node == state.node)
-        precondition(childConversion.state.event == CMARK_EVENT_EXIT)
-        return MarkupConversion(state: childConversion.state.next(), result: .heading(level: headingLevel, parsedRange: parsedRange, childConversion.result))
-    }
-
-    private static func convertThematicBreak(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .thematicBreak)
-        let parsedRange = state.range(state.node)
-        return MarkupConversion(state: state.next(), result: .thematicBreak(parsedRange: parsedRange))
-    }
-
-    private static func convertText(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .text)
-        let parsedRange = state.range(state.node)
-        let string = getLiteralContent(node: state.node)
-        return MarkupConversion(state: state.next(), result: .text(parsedRange: parsedRange, string: string))
-    }
-
-    private static func convertSoftBreak(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .softBreak)
-        let parsedRange = state.range(state.node)
-        return MarkupConversion(state: state.next(), result: .softBreak(parsedRange: parsedRange))
-    }
-
-    private static func convertLineBreak(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .lineBreak)
-        let parsedRange = state.range(state.node)
-        return MarkupConversion(state: state.next(), result: .lineBreak(parsedRange: parsedRange))
-    }
-
-    private static func convertInlineCode(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .code)
-        let parsedRange = state.range(state.node)
-        let literalContent = getLiteralContent(node: state.node)
-        if state.options.contains(.parseSymbolLinks),
-           cmark_node_get_backtick_count(state.node) > 1 {
-            return MarkupConversion(state: state.next(), result: .symbolLink(parsedRange: parsedRange, destination: literalContent))
-        } else {
-            return MarkupConversion(state: state.next(), result: .inlineCode(parsedRange: parsedRange, code: literalContent))
-        }
-    }
-
-    private static func convertInlineHTML(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .html)
-        let parsedRange = state.range(state.node)
-        let html = getLiteralContent(node: state.node)
-        return MarkupConversion(state: state.next(), result: .inlineHTML(parsedRange: parsedRange, html: html))
-    }
-
-    private static func convertCustomInline(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .customInline)
-        let parsedRange = state.range(state.node)
-        let text = getLiteralContent(node: state.node)
-        return MarkupConversion(state: state.next(), result: .customInline(parsedRange: parsedRange, text: text))
-    }
-
-    private static func convertEmphasis(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .emphasis)
-        let parsedRange = state.range(state.node)
-        let childConversion = convertChildren(state)
-        precondition(childConversion.state.node == state.node)
-        precondition(childConversion.state.event == CMARK_EVENT_EXIT)
-        return MarkupConversion(state: childConversion.state.next(), result: .emphasis(parsedRange: parsedRange, childConversion.result))
-    }
-
-    private static func convertStrong(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .strong)
-        let parsedRange = state.range(state.node)
-        let childConversion = convertChildren(state)
-        precondition(childConversion.state.node == state.node)
-        precondition(childConversion.state.event == CMARK_EVENT_EXIT)
-        return MarkupConversion(state: childConversion.state.next(), result: .strong(parsedRange: parsedRange, childConversion.result))
-    }
-
-    private static func convertLink(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .link)
-        let parsedRange = state.range(state.node)
-        let childConversion = convertChildren(state)
-        let destination = String(cString: cmark_node_get_url(state.node))
-        let title = String(cString: cmark_node_get_title(state.node))
-        precondition(childConversion.state.node == state.node)
-        precondition(childConversion.state.event == CMARK_EVENT_EXIT)
-        return MarkupConversion(
-            state: childConversion.state.next(),
-            result: .link(
-                destination: destination.isEmpty ? nil : destination,
-                title: title.isEmpty ? nil : title,
-                parsedRange: parsedRange,
-                childConversion.result
-            )
-        )
-    }
-
-    private static func convertImage(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .image)
-        let parsedRange = state.range(state.node)
-        let childConversion = convertChildren(state)
-        let source = String(cString: cmark_node_get_url(state.node))
-        let title = String(cString: cmark_node_get_title(state.node))
-        precondition(childConversion.state.node == state.node)
-        precondition(childConversion.state.event == CMARK_EVENT_EXIT)
-        return MarkupConversion(
-            state: childConversion.state.next(),
-            result: .image(
-                source: source.isEmpty ? nil : source,
-                title: title.isEmpty ? nil : title,
-                parsedRange: parsedRange, childConversion.result
-            )
-        )
-    }
-
-    private static func convertStrikethrough(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .strikethrough)
-        let parsedRange = state.range(state.node)
-        let childConversion = convertChildren(state)
-        precondition(childConversion.state.node == state.node)
-        precondition(childConversion.state.event == CMARK_EVENT_EXIT)
-        return MarkupConversion(state: childConversion.state.next(), result: .strikethrough(parsedRange: parsedRange, childConversion.result))
-    }
-
-    private static func convertTaskListItem(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .taskListItem)
-        let parsedRange = state.range(state.node)
-        let childConversion = convertChildren(state)
-        let checkbox: Checkbox = cmark_gfm_extensions_get_tasklist_item_checked(state.node) ? .checked : .unchecked
-        precondition(childConversion.state.node == state.node)
-        precondition(childConversion.state.event == CMARK_EVENT_EXIT)
-        return MarkupConversion(state: childConversion.state.next(), result: .listItem(checkbox: checkbox, parsedRange: parsedRange, childConversion.result))
-    }
-
-    private static func convertTable(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .table)
-        let parsedRange = state.range(state.node)
-        let columnCount = Int(cmark_gfm_extensions_get_table_columns(state.node))
-        let columnAlignments = (0..<columnCount).map { column -> Table.ColumnAlignment? in
-            // cmark tracks left, center, and right alignments as the ASCII
-            // characters 'l', 'c', and 'r'.
-            let ascii = cmark_gfm_extensions_get_table_alignments(state.node)[column]
-            let scalar = UnicodeScalar(ascii)
-            let character = Character(scalar)
-            switch character {
-            case "l":
-                return .left
-            case "r":
-                return .right
-            case "c":
-                return .center
-            case "\0":
-                return nil
-            default:
-                fatalError("Unexpected table column character for cmark table: \(character) (0x\(String(ascii, radix: 16)))")
+    
+    /// Converts a leaf cmark node directly into its corresponding `RawMarkup` representation.
+    private static func createLeaf(nodeType: CommonMarkNodeType, node: UnsafeMutablePointer<cmark_node>, parsedRange: SourceRange?, state: MarkupConverterState) -> RawMarkup {
+        switch nodeType {
+        case .codeBlock:
+            let language = String(cString: cmark_node_get_fence_info(node))
+            let code = getLiteralContent(node: node)
+            return .codeBlock(parsedRange: parsedRange, code: code, language: language.isEmpty ? nil : language)
+        case .htmlBlock:
+            return .htmlBlock(parsedRange: parsedRange, html: getLiteralContent(node: node))
+        case .thematicBreak:
+            return .thematicBreak(parsedRange: parsedRange)
+        case .text:
+            return .text(parsedRange: parsedRange, string: getLiteralContent(node: node))
+        case .softBreak:
+            return .softBreak(parsedRange: parsedRange)
+        case .lineBreak:
+            return .lineBreak(parsedRange: parsedRange)
+        case .code:
+            let literalContent = getLiteralContent(node: node)
+            if state.options.contains(.parseSymbolLinks), cmark_node_get_backtick_count(node) > 1 {
+                return .symbolLink(parsedRange: parsedRange, destination: literalContent)
+            } else {
+                return .inlineCode(parsedRange: parsedRange, code: literalContent)
             }
+        case .html:
+            return .inlineHTML(parsedRange: parsedRange, html: getLiteralContent(node: node))
+        case .customInline:
+            return .customInline(parsedRange: parsedRange, text: getLiteralContent(node: node))
+        default:
+            fatalError("Unhandled leaf node type: \(nodeType)")
         }
-
-        let childConversion = convertChildren(state)
-        precondition(childConversion.state.node == state.node)
-        precondition(childConversion.state.event == CMARK_EVENT_EXIT)
-
-        var children = childConversion.result
-
-        let header: RawMarkup
-        if let firstChild = children.first,
-           case .tableHead = firstChild.data {
-            header = firstChild
-            children.removeFirst()
-        } else {
-            header = .tableHead(parsedRange: nil, columns: [])
-        }
-
-        if children.isEmpty {
-            precondition(childConversion.state.pendingTableBody == nil)
-        }
-
-        let body: RawMarkup
-        if !children.isEmpty {
-            let pendingBody = childConversion.state.pendingTableBody!
-            body = RawMarkup.tableBody(parsedRange: pendingBody.range, rows: children)
-        } else {
-            body = .tableBody(parsedRange: nil, rows: [])
-        }
-
-        return MarkupConversion(state: childConversion.state.next(clearPendingTableBody: true),
-                                result: .table(columnAlignments: columnAlignments,
-                                               parsedRange: parsedRange,
-                                               header: header,
-                                               body: body))
     }
 
-    private static func convertTableHeader(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .tableHead)
-        let parsedRange = state.range(state.node)
-        let childConversion = convertChildren(state)
-        precondition(childConversion.state.node == state.node)
-        precondition(childConversion.state.event == CMARK_EVENT_EXIT)
-        return MarkupConversion(state: childConversion.state.next(), result: .tableHead(parsedRange: parsedRange, columns: childConversion.result))
-    }
+    /// Converts a completed parsing frame into its corresponding `RawMarkup` node.
+    ///
+    /// This is called when the matching `CMARK_EVENT_EXIT` is encountered.
+    /// At that point all descendant nodes have already been converted and
+    /// accumulated in `frame.children`.
+    private static func createContainer(frame: ParsingFrame, state: MarkupConverterState) -> RawMarkup {
+        let node = frame.node
+        let children = frame.children
+        let parsedRange = frame.parsedRange
 
-    private static func convertTableRow(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .tableRow)
-        let parsedRange = state.range(state.node)
-        let childConversion = convertChildren(state)
-        precondition(childConversion.state.node == state.node)
-        precondition(childConversion.state.event == CMARK_EVENT_EXIT)
-        return MarkupConversion(state: childConversion.state.next(), result: .tableRow(parsedRange: parsedRange, childConversion.result))
-    }
+        switch frame.nodeType {
+        case .document:
+            return .document(parsedRange: parsedRange, children)
+        case .blockQuote:
+            return .blockQuote(parsedRange: parsedRange, children)
+        case .list:
+            for child in children {
+                guard case .listItem = child.data else { fatalError("Converted cmark list had a non-listItem node") }
+            }
+            switch cmark_node_get_list_type(node) {
+            case CMARK_BULLET_LIST:
+                return .unorderedList(parsedRange: parsedRange, children)
+            case CMARK_ORDERED_LIST:
+                let cmarkStart = UInt(cmark_node_get_list_start(node))
+                return .orderedList(parsedRange: parsedRange, children, startIndex: cmarkStart)
+            default:
+                fatalError("cmark reported a list node but said its list type is CMARK_NO_LIST?")
+            }
+        case .item:
+            return .listItem(checkbox: .none, parsedRange: parsedRange, children)
+        case .customBlock:
+            return .customBlock(parsedRange: parsedRange, children)
+        case .paragraph:
+            return .paragraph(parsedRange: parsedRange, children)
+        case .heading:
+            let headingLevel = Int(cmark_node_get_heading_level(node))
+            return .heading(level: headingLevel, parsedRange: parsedRange, children)
+        case .emphasis:
+            return .emphasis(parsedRange: parsedRange, children)
+        case .strong:
+            return .strong(parsedRange: parsedRange, children)
+        case .link:
+            let destination = String(cString: cmark_node_get_url(node))
+            let title = String(cString: cmark_node_get_title(node))
+            return .link(destination: destination.isEmpty ? nil : destination, title: title.isEmpty ? nil : title, parsedRange: parsedRange, children)
+        case .image:
+            let source = String(cString: cmark_node_get_url(node))
+            let title = String(cString: cmark_node_get_title(node))
+            return .image(source: source.isEmpty ? nil : source, title: title.isEmpty ? nil : title, parsedRange: parsedRange, children)
+        case .strikethrough:
+            return .strikethrough(parsedRange: parsedRange, children)
+        case .taskListItem:
+            let checkbox: Checkbox = cmark_gfm_extensions_get_tasklist_item_checked(node) ? .checked : .unchecked
+            return .listItem(checkbox: checkbox, parsedRange: parsedRange, children)
+        case .table:
+            let columnCount = Int(cmark_gfm_extensions_get_table_columns(node))
+            let columnAlignments = (0..<columnCount).map { column -> Table.ColumnAlignment? in
+                let ascii = cmark_gfm_extensions_get_table_alignments(node)[column]
+                switch Character(UnicodeScalar(ascii)) {
+                case "l": return .left
+                case "r": return .right
+                case "c": return .center
+                case "\0": return nil
+                default: fatalError("Unexpected table column character")
+                }
+            }
 
-    private static func convertTableCell(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .tableCell)
-        let parsedRange = state.range(state.node)
-        let childConversion = convertChildren(state)
-        let colspan = UInt(cmark_gfm_extensions_get_table_cell_colspan(state.node))
-        let rowspan = UInt(cmark_gfm_extensions_get_table_cell_rowspan(state.node))
-        precondition(childConversion.state.node == state.node)
-        precondition(childConversion.state.event == CMARK_EVENT_EXIT)
-        return MarkupConversion(state: childConversion.state.next(), result: .tableCell(parsedRange: parsedRange, colspan: colspan, rowspan: rowspan, childConversion.result))
-    }
+            var mutableChildren = children
+            let header: RawMarkup
+            // GFM tables are represented as a header followed by body rows.
+            if let firstChild = mutableChildren.first, case .tableHead = firstChild.data {
+                header = firstChild
+                mutableChildren.removeFirst()
+            } else {
+                header = .tableHead(parsedRange: nil, columns: [])
+            }
 
-    private static func convertInlineAttributes(_ state: MarkupConverterState) -> MarkupConversion<RawMarkup> {
-        precondition(state.event == CMARK_EVENT_ENTER)
-        precondition(state.nodeType == .inlineAttributes)
-        let parsedRange = state.range(state.node)
-        let childConversion = convertChildren(state)
-        let attributes = String(cString: cmark_node_get_attributes(state.node))
-        precondition(childConversion.state.node == state.node)
-        precondition(childConversion.state.event == CMARK_EVENT_EXIT)
-        return MarkupConversion(state: childConversion.state.next(), result: .inlineAttributes(attributes: attributes, parsedRange: parsedRange, childConversion.result))
-     }
+            let body: RawMarkup
+            if !mutableChildren.isEmpty {
+                let pendingBodyRange = state.pendingTableBody?.range
+                body = .tableBody(parsedRange: pendingBodyRange, rows: mutableChildren)
+            } else {
+                body = .tableBody(parsedRange: nil, rows: [])
+            }
+            return .table(columnAlignments: columnAlignments, parsedRange: parsedRange, header: header, body: body)
+        case .tableHead:
+            return .tableHead(parsedRange: parsedRange, columns: children)
+        case .tableRow:
+            return .tableRow(parsedRange: parsedRange, children)
+        case .tableCell:
+            let colspan = UInt(cmark_gfm_extensions_get_table_cell_colspan(node))
+            let rowspan = UInt(cmark_gfm_extensions_get_table_cell_rowspan(node))
+            return .tableCell(parsedRange: parsedRange, colspan: colspan, rowspan: rowspan, children)
+        case .inlineAttributes:
+            let attributes = String(cString: cmark_node_get_attributes(node))
+            return .inlineAttributes(attributes: attributes, parsedRange: parsedRange, children)
+        default:
+            fatalError("Unknown container node type '\(frame.nodeType.rawValue)'")
+        }
+    }
 
     static func parseString(_ string: String, source: URL?, options: ParseOptions) -> Document {
         cmark_gfm_core_extensions_ensure_registered()
@@ -626,28 +360,66 @@ struct MarkupParser {
         cmark_parser_attach_syntax_extension(parser, cmark_find_syntax_extension("tasklist"))
         cmark_parser_feed(parser, string, string.utf8.count)
         let rawDocument = cmark_parser_finish(parser)
-        let initialState = MarkupConverterState(source: source, iterator: cmark_iter_new(rawDocument), event: CMARK_EVENT_NONE, node: nil, options: options, headerSeen: false, pendingTableBody: nil).next()
-        precondition(initialState.event == CMARK_EVENT_ENTER)
-        precondition(initialState.nodeType == .document)
-        let conversion = convertAnyElement(initialState)
-        guard case .document = conversion.result.data else {
-            fatalError("cmark top-level conversion didn't produce a RawMarkup.document")
+        var state = MarkupConverterState(source: source, iterator: cmark_iter_new(rawDocument), event: CMARK_EVENT_NONE, node: nil, options: options, headerSeen: false, pendingTableBody: nil).next()
+        
+        precondition(state.event == CMARK_EVENT_ENTER)
+        precondition(state.nodeType == .document)
+
+        var stack = [ParsingFrame]()
+
+        while state.event != CMARK_EVENT_DONE && state.event != CMARK_EVENT_NONE {
+            guard let node = state.node else {
+                state = state.next()
+                continue
+            }
+            
+            let nodeType = state.nodeType
+            let parsedRange = state.range(node)
+
+            if state.event == CMARK_EVENT_ENTER {
+                if isLeaf(nodeType) {
+                    let leaf = createLeaf(nodeType: nodeType, node: node, parsedRange: parsedRange, state: state)
+                    precondition(!stack.isEmpty, "Leaf node encountered without a parent document on the stack.")
+                    stack[stack.count - 1].children.append(leaf)
+                } else {
+                    stack.append(ParsingFrame(node: node, nodeType: nodeType, parsedRange: parsedRange))
+                }
+                state = state.next()
+                
+            } else if state.event == CMARK_EVENT_EXIT {
+                if isLeaf(nodeType) {
+                    state = state.next()
+                } else {
+                    let frame = stack.removeLast()
+                    precondition(frame.node == node)
+                    
+                    let container = createContainer(frame: frame, state: state)
+                    
+                    if stack.isEmpty {
+                        precondition(frame.nodeType == .document)
+                        let iterator = state.iterator
+                        
+                        cmark_iter_free(iterator)
+                        cmark_node_free(rawDocument)
+                        cmark_parser_free(parser)
+                        
+                        let data = _MarkupData(AbsoluteRawMarkup(markup: container, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0)))
+                        return makeMarkup(data) as! Document
+                        
+                    } else {
+                        stack[stack.count - 1].children.append(container)
+                        if nodeType == .table {
+                            state = state.next(clearPendingTableBody: true)
+                        } else {
+                            state = state.next()
+                        }
+                    }
+                }
+            } else {
+                state = state.next()
+            }
         }
 
-        let finalState = conversion.state.next()
-        precondition(finalState.event == CMARK_EVENT_DONE)
-        precondition(finalState.node == nil)
-        precondition(initialState.iterator == finalState.iterator)
-
-        precondition(initialState.node != nil)
-
-        cmark_node_free(initialState.node)
-        cmark_iter_free(finalState.iterator)
-        cmark_parser_free(parser)
-
-        let data = _MarkupData(AbsoluteRawMarkup(markup: conversion.result,
-                                                metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0)))
-        return makeMarkup(data) as! Document
+        fatalError("cmark iteration terminated prematurely without cleanly exiting the document root.")
     }
 }
-

--- a/Tests/MarkdownTests/Base/RawMarkupTests.swift
+++ b/Tests/MarkdownTests/Base/RawMarkupTests.swift
@@ -56,6 +56,33 @@ final class RawMarkupTests: XCTestCase {
             XCTAssertFalse(document1.hasSameStructure(as: document2))
         }
     }
+    
+    /// Verify that tables with different column alignments do not have the same structure.
+    func testTableStructure() {
+        let table1 = RawMarkup.table(
+            columnAlignments: [.left, .right],
+            parsedRange: nil,
+            header: .tableHead(parsedRange: nil, columns: []),
+            body: .tableBody(parsedRange: nil, rows: [])
+        )
+            
+        let table2 = RawMarkup.table(
+            columnAlignments: [.left, .right],
+            parsedRange: nil,
+            header: .tableHead(parsedRange: nil, columns: []),
+            body: .tableBody(parsedRange: nil, rows: [])
+        )
+            
+        let table3 = RawMarkup.table(
+            columnAlignments: [.center, .right],
+            parsedRange: nil,
+            header: .tableHead(parsedRange: nil, columns: []),
+            body: .tableBody(parsedRange: nil, rows: [])
+        )
+
+        XCTAssertTrue(table1.hasSameStructure(as: table2))
+        XCTAssertFalse(table1.hasSameStructure(as: table3))
+    }
 
     /// When an element changes a child, unchanged children should use the same `RawMarkup` as before.
     func testSharing() {

--- a/Tests/MarkdownTests/Base/RawMarkupTests.swift
+++ b/Tests/MarkdownTests/Base/RawMarkupTests.swift
@@ -102,4 +102,18 @@ final class RawMarkupTests: XCTestCase {
         XCTAssertFalse(originalRoot.child(at: 0)!.raw.markup === newRoot.child(at: 0)!.raw.markup)
         XCTAssertTrue(originalRoot.child(at: 1)!.raw.markup === newRoot.child(at: 1)!.raw.markup)
     }
+    
+    func testTrulyDeepNestingDeallocation() {
+        let depth = 15000
+
+        do {
+            var current = RawMarkup.text(parsedRange: nil, string: "Deep Leaf")
+
+            for _ in 0..<depth {
+                current = RawMarkup.blockQuote(parsedRange: nil, [current])
+            }
+        }
+
+        XCTAssertTrue(true)
+    }
 }

--- a/Tests/MarkdownTests/Parsing/CommonMarkConverterTests.swift
+++ b/Tests/MarkdownTests/Parsing/CommonMarkConverterTests.swift
@@ -93,7 +93,7 @@ class CommonMarkConverterTests: XCTestCase {
         var currentNode: Markup = document
         var actualDepth = 0
         
-        while let child = currentNode.child(at: 0) {
+        while let child = currentNode.child(at: 0)  {
             currentNode = child
             actualDepth += 1
         }

--- a/Tests/MarkdownTests/Parsing/CommonMarkConverterTests.swift
+++ b/Tests/MarkdownTests/Parsing/CommonMarkConverterTests.swift
@@ -33,4 +33,83 @@ class CommonMarkConverterTests: XCTestCase {
         let document = Document(parsing: text, source: nil, options: [.parseBlockDirectives, .parseSymbolLinks])
         XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
     }
+    
+    /// Verify that enabling block directive parsing does not alter the structure or source ranges of ordinary multiline links.
+    func testMultilineLinksWithBlockDirectives() {
+        let text =
+            "This is a link to an article on a different domain [link\n" +
+            "to an article](https://www.host.com/article)."
+
+        let plain = Document(parsing: text, source: nil, options: [.parseSymbolLinks])
+        let withDirectives = Document(parsing: text, source: nil, options: [.parseBlockDirectives, .parseSymbolLinks])
+
+        XCTAssertEqual(
+            plain.debugDescription(options: .printSourceLocations),
+            withDirectives.debugDescription(options: .printSourceLocations),
+            "BlockDirectiveParser must preserve inline children of plain paragraphs"
+        )
+    }
+    
+    /// Verify that deeply nested block and list structures preserve the  expected hierarchy and source ranges during conversion.
+    func testNestedStructureRanges() {
+        let text = """
+        > Blockquote
+        > - List item
+        >   - Nested list item
+        >     1. Deepest item
+        """
+        
+        let expectedDump = """
+        Document @1:1-4:22
+        └─ BlockQuote @1:1-4:22
+           ├─ Paragraph @1:3-1:13
+           │  └─ Text @1:3-1:13 "Blockquote"
+           └─ UnorderedList @2:3-4:22
+              └─ ListItem @2:3-4:22
+                 ├─ Paragraph @2:5-2:14
+                 │  └─ Text @2:5-2:14 "List item"
+                 └─ UnorderedList @3:5-4:22
+                    └─ ListItem @3:5-4:22
+                       ├─ Paragraph @3:7-3:23
+                       │  └─ Text @3:7-3:23 "Nested list item"
+                       └─ OrderedList @4:7-4:22
+                          └─ ListItem @4:7-4:22
+                             └─ Paragraph @4:10-4:22
+                                └─ Text @4:10-4:22 "Deepest item"
+        """
+        
+        let document = Document(parsing: text)
+        XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
+    }
+
+    /// Verify that extremely deep nesting does not overflow the call stack during cmark-to-RawMarkup conversion.
+    func testTrulyDeepNestingStackUnwind() {
+        let depth = 15_000
+        
+        let text = String(repeating: "> ", count: depth) + "Deep"
+        
+        let document = Document(parsing: text)
+        
+        var currentNode: Markup = document
+        var actualDepth = 0
+        
+        while let child = currentNode.child(at: 0) {
+            currentNode = child
+            actualDepth += 1
+        }
+        
+        XCTAssertGreaterThan(actualDepth, depth)
+        XCTAssertEqual((currentNode as? Text)?.string, "Deep")
+    }
+
+    /// Verify that parsing an empty string produces a valid empty document.
+    func testEmptyDocument() {
+        let document = Document(parsing: "")
+        
+        let expectedDump = """
+        Document
+        """
+        
+        XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: Fixes #275

## Summary

Fix a stack overflow in Document(parsing:) caused by deeply nested Markdown structures.

Previously, swift-markdown converted the cmark AST to RawMarkup using recursive traversal. Inputs that produced extremely deep nesting could exhaust the call stack during conversion, causing the process to crash.

This change replaces the recursive conversion logic with an iterative implementation driven by the cmark_iter event stream. Container nodes are tracked using an explicit work stack and are finalized when their corresponding CMARK_EVENT_EXIT event is encountered. This prevents stack growth proportional to document nesting depth while preserving existing parser behavior.

Additional regression tests were added to verify:
- Deeply nested documents can be parsed without overflowing the stack.
- Multiline links continue to be parsed correctly.
- Block directive parsing preserves the structure and source locations of ordinary multiline links.
- Nested structures continue to produce the expected source ranges.

## Dependencies

N/A

## Testing

Run the full test suite

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
