### PR TITLE
Conform Aside.Kind to Hashable

### DIFF
--- a/Sources/Markdown/Interpretive Nodes/Aside.swift
+++ b/Sources/Markdown/Interpretive Nodes/Aside.swift
@@ -22,7 +22,7 @@ import Foundation
 /// ```
 public struct Aside {
     /// Describes the different kinds of aside.
-    public struct Kind: RawRepresentable, CaseIterable, Equatable, Sendable {
+    public struct Kind: RawRepresentable, CaseIterable, Hashable, Sendable {
         /// A "note" aside.
         public static let note = Kind(rawValue: "Note")!
         


### PR DESCRIPTION
Bug/issue Closes #277

## Summary

`Aside.Kind` currently conforms to `RawRepresentable`, `CaseIterable`, `Equatable`, and `Sendable`, but not to `Hashable`. This makes it impossible to use `Aside.Kind` directly in a `Set`, as a dictionary key, or as a stored value of another `Hashable` type (for example, an enum case carrying an `Aside.Kind`) without declaring a retroactive conformance downstream:

```swift
extension Aside.Kind: @retroactive Hashable {}
```

Retroactive conformances emit warnings and risk a future conflict if the library adds the conformance itself.

This PR adds `Hashable` conformance to `Aside.Kind`. Since the type's only stored property is `rawValue: String` (which is already `Hashable`), the conformance is synthesized by the compiler and requires no manual implementation. The change is purely additive and source-compatible.

## Dependencies

None.

## Testing

There is no user-facing behavior change; the addition can be verified at the type level.

Steps:
1. 1Check out this branch and build the `Markdown` module.
2. 2Confirm the following compiles:
```swift
   import Markdown

   let kinds: Set<Aside.Kind> = [.note, .tip, .warning]
   let counts: [Aside.Kind: Int] = [.note: 1]
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
