### PR TITLE
Render nested markup inside headings in HTMLFormatter

### DIFF
--- a/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
@@ -90,7 +90,9 @@ public struct HTMLFormatter: MarkupWalker {
     }
 
     public mutating func visitHeading(_ heading: Heading) -> () {
-        result += "<h\(heading.level)>\(heading.plainText)</h\(heading.level)>\n"
+        result += "<h\(heading.level)>"
+        descendInto(heading)
+        result += "</h\(heading.level)>\n"
     }
 
     public mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) -> () {

--- a/Tests/MarkdownTests/Visitors/HTMLFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/HTMLFormatterTests.swift
@@ -365,11 +365,11 @@ final class HTMLFormatterTests: XCTestCase {
             let inputText = """
             ## [0.0.1] - 2014-05-31
 
-            [0.0.1]: https://github.com/olivierlacan/keep-a-changelog/
+            [0.0.1]: https://example.com/project/keep-a-changelog/
             """
             
             let expectedOutput = """
-            <h2><a href="https://github.com/olivierlacan/keep-a-changelog/">0.0.1</a> - 2014-05-31</h2>
+            <h2><a href="https://example.com/project/keep-a-changelog/">0.0.1</a> - 2014-05-31</h2>
             
             """
             

--- a/Tests/MarkdownTests/Visitors/HTMLFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/HTMLFormatterTests.swift
@@ -359,4 +359,47 @@ final class HTMLFormatterTests: XCTestCase {
         XCTAssertEqual(HTMLFormatter.format(inputText), expectedOutput)
       }
     }
+    
+    func testFormatHeadingWithNestedMarkup() {
+        do {
+            let inputText = """
+            ## [0.0.1] - 2014-05-31
+
+            [0.0.1]: https://github.com/olivierlacan/keep-a-changelog/
+            """
+            
+            let expectedOutput = """
+            <h2><a href="https://github.com/olivierlacan/keep-a-changelog/">0.0.1</a> - 2014-05-31</h2>
+            
+            """
+            
+            XCTAssertEqual(HTMLFormatter.format(inputText), expectedOutput)
+        }
+        
+        do {
+            let inputText = """
+            # Heading with a [link](https://example.com) and `code`
+            """
+            
+            let expectedOutput = """
+            <h1>Heading with a <a href="https://example.com">link</a> and <code>code</code></h1>
+            
+            """
+            
+            XCTAssertEqual(HTMLFormatter.format(inputText), expectedOutput)
+        }
+        
+        do {
+            let inputText = """
+            ### **Strong** and *Emphasized* text
+            """
+            
+            let expectedOutput = """
+            <h3><strong>Strong</strong> and <em>Emphasized</em> text</h3>
+            
+            """
+            
+            XCTAssertEqual(HTMLFormatter.format(inputText), expectedOutput)
+        }
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: Fixes #262

## Summary

HTMLFormatter.visitHeading(_:) rendered headings using heading.plainText, which stripped all nested inline markup. As a result, links, emphasis, strong text, inline code, and other inline elements inside headings were lost in the generated HTML. Updated HTMLFormatter.visitHeading(_:) to render a heading's child markup by descending into its children instead of using heading.plainText.

## Dependencies

N/A

## Testing

Added regression tests covering:

- Reference-style links inside headings (the reported issue).
- Inline links and inline code inside headings.
- Emphasis and strong text inside headings.

Steps:
Run HTMLFormatterTests

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
