### PR TITLE
Fix inline code wrapping idempotence

### DIFF
--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -579,6 +579,19 @@ public struct MarkupFormatter: MarkupWalker {
         state.newlineStreak = 0
     }
 
+    /// Remove trailing spaces that have already been printed on the current line.
+    private static func trimTrailingSpaces(
+        from currentResult: inout String,
+        state currentState: inout State,
+        preserving minimumLineLength: Int = 0
+    ) {
+        while currentResult.last == " " && currentState.lastLineLength > minimumLineLength {
+            currentResult.removeLast()
+            currentState.currentLength -= 1
+            currentState.lastLineLength -= 1
+        }
+    }
+
     /// Print raw text while visiting an element, wrapping automatically with
     /// soft or hard line breaks.
     ///
@@ -619,6 +632,7 @@ public struct MarkupFormatter: MarkupWalker {
                 // we might already be right at the edge of a line when
                 // this method was called.
                 if state.lastLineLength + word.count >= lineLimit.maxLength {
+                    Self.trimTrailingSpaces(from: &result, state: &state, preserving: linePrefix(for: element).count)
                     queueNewline()
                 }
                 print(word, for: element)
@@ -803,16 +817,29 @@ public struct MarkupFormatter: MarkupWalker {
     }
 
     public mutating func visitInlineCode(_ inlineCode: InlineCode) {
+        if state.queuedNewlines > 0 {
+            print("", for: inlineCode)
+        }
+
         let savedState = state
+        var trimmedResult = result
+        var trimmedState = state
+        let prefixLength = linePrefix(for: inlineCode).count
+        Self.trimTrailingSpaces(from: &trimmedResult, state: &trimmedState, preserving: prefixLength)
+
         softWrapPrint("`\(inlineCode.code)`", for: inlineCode)
 
+        let isAtStartOfLine = trimmedState.lastLineLength <= prefixLength
         // Splitting inline code elements is allowed if it contains spaces.
         // If printing with automatic wrapping still put us over the line,
         // prefer to print it on the next line to give as much opportunity
         // to keep the contents on one line.
-        if inlineCode.indexInParent > 0 && (isOverPreferredLineLimit || state.effectiveLineNumber > savedState.effectiveLineNumber) {
-            restoreState(to: savedState)
+        if inlineCode.indexInParent > 0 && !isAtStartOfLine &&
+            (isOverPreferredLineLimit || state.effectiveLineNumber > savedState.effectiveLineNumber) {
+            result = trimmedResult
+            state = trimmedState
             queueNewline()
+            print("", for: inlineCode)
             softWrapPrint("`\(inlineCode.code)`", for: inlineCode)
         }
     }

--- a/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
@@ -1372,6 +1372,132 @@ class MarkupFormatterLineSplittingTests: XCTestCase {
         XCTAssertEqual(expected, printed)
         XCTAssertTrue(document.hasSameStructure(as: Document(parsing: printed)))
     }
+
+    /**
+     Test that line wrapping near an inline code block does not emit extra newlines,
+     and that formatting the same document multiple times is idempotent.
+     */
+    func testInlineCodeWrappingIdempotence() {
+        let source = "This indent is applied independently of `contributesBlockIndent`, which means a given break may apply both a continuation indent and a block indent, either indent, or neither indent."
+        
+        let expected = """
+        This indent is applied independently of
+        `contributesBlockIndent`, which means a given break
+        may apply both a continuation indent and a block
+        indent, either indent, or neither indent.
+        """
+        
+        let options = MarkupFormatter.Options(
+            preferredLineLimit: .init(maxLength: 55, breakWith: .softBreak)
+        )
+        
+        let document1 = Document(parsing: source)
+        let trip1 = document1.format(options: options)
+        
+        XCTAssertEqual(expected, trip1, "First formatting pass failed to wrap correctly without extra newlines.")
+        
+        let document2 = Document(parsing: trip1)
+        let trip2 = document2.format(options: options)
+        
+        XCTAssertEqual(trip1, trip2, "Formatter is not idempotent; second pass changed the output.")
+    }
+    
+    /**
+     Test that wrapping inline code inside a list item correctly preserves
+     the list item's indentation prefix without duplicating or dropping it.
+     */
+    func testInlineCodeInListWrappingIdempotence() {
+        let source = "- This indent is applied independently of `contributesBlockIndent`, which means a given break may apply."
+        
+        let expected = """
+        - This indent is applied independently of
+          `contributesBlockIndent`, which means a
+          given break may apply.
+        """
+        
+        let options = MarkupFormatter.Options(
+            preferredLineLimit: .init(maxLength: 45, breakWith: .softBreak)
+        )
+        
+        let trip1 = Document(parsing: source).format(options: options)
+        XCTAssertEqual(expected, trip1, "List prefix was not preserved correctly during wrap.")
+        
+        let trip2 = Document(parsing: trip1).format(options: options)
+        XCTAssertEqual(trip1, trip2, "List formatting is not idempotent.")
+    }
+    
+    /**
+     Test that inline code safely handles pre-existing soft breaks in the AST
+     without triggering double-newlines or ghost spaces.
+     */
+    func testInlineCodeWithExistingSoftBreaksIdempotence() {
+        let source = """
+        Some text before
+        `inlineCode`
+        Some text after
+        """
+        
+        let expected = "Some text before `inlineCode` Some text after"
+        
+        let options = MarkupFormatter.Options(
+            preferredLineLimit: .init(maxLength: 55, breakWith: .softBreak)
+        )
+        
+        let trip1 = Document(parsing: source).format(options: options)
+        XCTAssertEqual(expected, trip1, "Formatter mishandled existing soft breaks near inline code.")
+        
+        let trip2 = Document(parsing: trip1).format(options: options)
+        XCTAssertEqual(trip1, trip2, "Soft break formatting is not idempotent.")
+    }
+    
+    /**
+     Test that wrapping inline code inside a blockquote correctly preserves
+     the blockquote prefix (`> `).
+     */
+    func testInlineCodeInBlockquoteWrappingIdempotence() {
+        let source = "> This is `inlineCode` that wraps because it is very very very long."
+        
+        let expected = """
+        > This is `inlineCode` that
+        > wraps because it is very
+        > very very long.
+        """
+        
+        let options = MarkupFormatter.Options(
+            preferredLineLimit: .init(maxLength: 30, breakWith: .softBreak)
+        )
+        
+        let trip1 = Document(parsing: source).format(options: options)
+        XCTAssertEqual(expected, trip1, "Blockquote prefix was not preserved correctly.")
+        
+        let trip2 = Document(parsing: trip1).format(options: options)
+        XCTAssertEqual(trip1, trip2, "Blockquote formatting is not idempotent.")
+    }
+    
+    /**
+     Test that wrapping inline code inside an ordered list correctly calculates
+     and preserves the dynamic numeral prefix length.
+     */
+    func testInlineCodeInOrderedListWrappingIdempotence() {
+        let source = "1. This is `inlineCode` that wraps because it is very very very long."
+        
+        let expected = """
+        1. This is `inlineCode`
+           that wraps because it
+           is very very very
+           long.
+        """
+        
+        let options = MarkupFormatter.Options(
+            preferredLineLimit: .init(maxLength: 25, breakWith: .softBreak)
+        )
+        
+        let trip1 = Document(parsing: source).format(options: options)
+        XCTAssertEqual(expected, trip1, "Ordered list prefix was not preserved correctly.")
+        
+        let trip2 = Document(parsing: trip1).format(options: options)
+        XCTAssertEqual(trip1, trip2, "Ordered list formatting is not idempotent.")
+    }
 }
 
 class MarkupFormatterTableTests: XCTestCase {


### PR DESCRIPTION
Bug/issue #, if applicable: Fixes #197

## Summary

Fix inline code wrapping idempotence and trailing whitespace handling

Prevent extra newlines and trailing spaces when wrapping inline code by trimming trailing whitespace before queued line breaks and preserving formatter state during speculative inline code layout. This restores idempotency across repeated formatting passes.

## Dependencies

N/A

## Testing

Adds regression tests that cover inline code wrapping in paragraphs, lists, ordered lists, blockquotes, and existing soft-break scenarios

Steps:
Run MarkupFormatterTests

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
